### PR TITLE
New expression API

### DIFF
--- a/cpp/binary_expr.cxx
+++ b/cpp/binary_expr.cxx
@@ -35,4 +35,12 @@ int main(){
       std::cout << c << std::endl;
    }
 
+   {
+      std::cout << "Matrix vector multiplication\n";
+      auto a = ten::range<ten::matrix<float>>({3, 3});
+      auto b = ten::range<ten::vector<float>>({3});
+      auto c = (a * b).eval();
+      std::cout << c << std::endl;
+   }
+
 }

--- a/cpp/binary_expr.cxx
+++ b/cpp/binary_expr.cxx
@@ -1,0 +1,38 @@
+#include <ten/tensor>
+
+int main(){
+   auto x = ten::range<ten::vector<float>>({10}, 1.);
+   auto y = ten::range<ten::vector<float>>({10}, 1.);
+
+   {
+      auto z = x + y;
+      auto t = z.eval();
+      std::cout << t << std::endl;
+   }
+
+   {
+      auto z = (x - y).eval();
+      std::cout << z << std::endl;
+   }
+
+   {
+      auto z = (x / y).eval();
+      std::cout << z << std::endl;
+   }
+
+
+   {
+      std::cout << "X\n";
+      auto z = (x * y).eval();
+      std::cout << z << std::endl;
+   }
+
+   {
+      std::cout << "Matrix multiplication\n";
+      auto a = ten::range<ten::matrix<float>>({3, 3});
+      auto b = ten::range<ten::matrix<float>>({3, 3});
+      auto c = (a * b).eval();
+      std::cout << c << std::endl;
+   }
+
+}

--- a/cpp/binary_expr.cxx
+++ b/cpp/binary_expr.cxx
@@ -43,4 +43,11 @@ int main(){
       std::cout << c << std::endl;
    }
 
+   {
+      std::cout << "Scalar tensor multiplication\n";
+      auto a = ten::range<ten::matrix<float>>({3, 3});
+      auto b = 2.0f * a;
+      std::cout << b.eval() << std::endl;
+   }
+
 }

--- a/cpp/binary_expr.cxx
+++ b/cpp/binary_expr.cxx
@@ -50,4 +50,53 @@ int main(){
       std::cout << b.eval() << std::endl;
    }
 
+   {
+      std::cout << "Chaining\n";
+      auto x = ten::range<ten::matrix<float>>({3, 3});
+      auto y = ten::range<ten::matrix<float>>({3, 3});
+      // UnaryExpr * matrix
+      auto a = ten::sqrt(x);
+      auto b = a * y;
+      std::cout << b.eval() << std::endl;
+      // matrix * UnaryExpr
+      auto c = y * a;
+      std::cout << c.eval() << std::endl;
+      // Unarexpr * UnaryExpr
+      auto d = a * a;
+      std::cout << d.eval() << std::endl;
+      // BinaryExpr * matrix
+      auto e = x * x;
+      auto f = e * x;
+      std::cout << e.eval() << std::endl;
+      std::cout << (x * x * x).eval() << std::endl;
+      // matrix * BinaryExpr
+      auto g = x * e;
+      std::cout << g.eval() << std::endl;
+   }
+
+   {
+      std::cout << "Chaining vector\n";
+      auto x = ten::range<ten::matrix<float>>({3, 3});
+      auto y = ten::range<ten::vector<float>>({3});
+      // UnaryExpr * vector
+      auto a = ten::sqrt(x);
+      auto b = a * y;
+      std::cout << b.eval() << std::endl;
+      // BinaryExpr * vector
+      std::cout << (x * x * y).eval() << std::endl;
+   }
+
+   {
+      std::cout << "Functions that returns a scalar\n";
+      auto x = ten::range<ten::vector<float>>({10});
+      auto y = ten::min(x);
+      std::cout << y.eval() << std::endl;
+      auto z = ten::max(x);
+      std::cout << z.eval() << std::endl;
+      auto a = ten::prod(x);
+      std::cout << a.eval() << std::endl;
+      auto b = ten::cum_sum(x);
+      std::cout << b.eval() << std::endl;
+   }
+
 }

--- a/cpp/expressions.cxx
+++ b/cpp/expressions.cxx
@@ -50,4 +50,32 @@ int main(){
       std::cout << a.eval() << std::endl;
    }
 
+   {
+      auto x = ten::range<ten::vector<int32_t>>({10});
+      auto y = ten::range<ten::vector<int32_t>>({10});
+      auto z = x + y;
+      std::cout << z.eval() << std::endl;
+   }
+
+   {
+      auto x = ten::range<ten::vector<uint32_t>>({10});
+      auto y = ten::range<ten::vector<uint32_t>>({10});
+      auto z = x + y;
+      std::cout << z.eval() << std::endl;
+   }
+
+   {
+      auto x = ten::range<ten::vector<int64_t>>({10});
+      auto y = ten::range<ten::vector<int64_t>>({10});
+      auto z = x + y;
+      std::cout << z.eval() << std::endl;
+   }
+
+   {
+      auto x = ten::range<ten::vector<size_t>>({10});
+      auto y = ten::range<ten::vector<size_t>>({10});
+      auto z = x + y;
+      std::cout << z.eval() << std::endl;
+   }
+
 }

--- a/cpp/expressions.cxx
+++ b/cpp/expressions.cxx
@@ -1,0 +1,53 @@
+#include "ten/tensor.hxx"
+#include <ten/tensor>
+
+int main(){
+   auto x = ten::range<ten::vector<float>>({10}, 1.);
+   auto y = ten::range<ten::vector<float>>({10}, 1.);
+
+   {
+      auto z = ten::cos(x);
+      std::cout << z.eval() << std::endl;
+   }
+
+
+   {
+      ten::vector<float> z = ten::cos(x);
+      std::cout << z << std::endl;
+   }
+
+   {
+      auto a = ten::cos(x);
+      ten::vector<float> b = a;
+      b[0] = 1.0f;
+      //std::cout << "b = " << b << std::endl;
+      //std::cout << "a = " << a.eval() << std::endl;
+      //std::cout << b.node().get() << " " << a.eval().node().get() << std::endl;
+   }
+
+   {
+      auto a = 2.0f * x;
+      std::cout << a.eval() << std::endl;
+   }
+
+   {
+      auto a = 2.0f + x;
+      std::cout << a.eval() << std::endl;
+   }
+
+   {
+      auto a = x + 2.0f;
+      std::cout << a.eval() << std::endl;
+   }
+
+   {
+      auto a = x - 1.0f;
+      std::cout << a.eval() << std::endl;
+   }
+
+   {
+      auto a = 1.0f - x;
+      std::cout << a.eval() << std::endl;
+   }
+
+}

--- a/cpp/ranked_column_row.cxx
+++ b/cpp/ranked_column_row.cxx
@@ -1,0 +1,47 @@
+#include <ten/tensor>
+
+int main() {
+   auto a = ten::range<ten::matrix<float>>({3, 4});
+
+   std::cout << a << std::endl;
+   {
+      auto col_0 = a.column(0);
+      std::cout << col_0 << std::endl;
+   }
+
+   {
+      auto row_0 = a.row(0);
+      std::cout << row_0 << std::endl;
+   }
+
+   {
+      auto b = ten::range<ten::vector<float>>({4});
+      auto c = a * b;
+      std::cout << c.eval() << std::endl;
+      auto col_0 = a.column(0);
+      col_0 = c;
+      std::cout << a << std::endl;
+   }
+
+   {
+      auto row_0 = a.row(0);
+      auto x = ten::range<ten::vector<float>>({4});
+      std::cout << "x = " << x << std::endl;
+      row_0 = x;
+      auto row_1 = a.row(1);
+      row_1 = x;
+      std::cout << a << std::endl;
+   }
+
+   {
+      auto col_0 = a.column(0);
+      auto x = ten::range<ten::vector<float>>({3});
+      col_0 = x;
+      std::cout << a << std::endl;
+      col_0 = x;
+      auto col_2 = a.column(2);
+      col_2 = x;
+      std::cout << a << std::endl;
+   }
+
+}

--- a/cpp/serialize.cxx
+++ b/cpp/serialize.cxx
@@ -1,30 +1,7 @@
-#include "ten/shape.hxx"
-#include "ten/tensor.hxx"
 #include <ten/tensor>
+#include <ten/io>
 
 int main() {
-   { // Storage
-      auto x = ten::range<ten::vector<float>>({10});
-      std::cout << "Data to write = " << std::endl;
-      std::cout << x << std::endl;
-
-      auto storage = x.storage();
-      auto st = storage.get();
-      std::ofstream ofs("vector.ten", std::ios_base::binary);
-      ten::serialize(ofs, *st);
-      ofs.close();
-
-      std::ifstream ifs("vector.ten", std::ios_base::binary);
-      using storage_type = decltype(x)::storage_type;
-      auto y = ten::deserialize<storage_type>(ifs);
-      ifs.close();
-
-      auto data = y.data();
-
-      std::cout << "Read data = " << std::endl;
-      for (size_t i = 0; i < y.size(); i++)
-         std::cout << data[i] << std::endl;
-   }
 
    { // Tensor node
       auto x = ten::range<ten::matrix<float>>({3, 4});
@@ -95,8 +72,8 @@ int main() {
    { // Tensor
       std::cout << "Tensor" << std::endl;
       auto x = ten::range<ten::matrix<float>>({3, 4});
-      ten::save(x, "tensor.ten");
-      auto y = ten::load<decltype(x)>("tensor.ten").value();
+      ten::io::save(x, "tensor.ten");
+      auto y = ten::io::load<decltype(x)>("tensor.ten").value();
       std::cout << "shape = " << y.shape() << std::endl;
       std::cout << "stride = " << y.strides() << std::endl;
       std::cout << "data = \n" << y << std::endl;

--- a/ten/config.hxx
+++ b/ten/config.hxx
@@ -35,10 +35,15 @@ enum class simd_backend { std, unknown };
 static simd_backend simd_backend_type = TENSEUR_SIMDBACKEND;
 
 // TODO Two simdvecLen default to 8 and 4 for floats, 4 and 2 for doubles
-#ifndef TENSEUR_SIMDVECLEN
-#define TENSEUR_SIMDVECLEN 32
+#ifndef TENSEUR_SIMDVECLEN_FLOAT
+#define TENSEUR_SIMDVECLEN_FLOAT 32
 #endif
-static constexpr size_t simd_vecLen = TENSEUR_SIMDVECLEN;
+static constexpr size_t simd_vecLen_float = TENSEUR_SIMDVECLEN_FLOAT;
+
+#ifndef TENSEUR_SIMDVECLEN_DOUBLE
+#define TENSEUR_SIMDVECLEN_DOUBLE 16
+#endif
+static constexpr size_t simd_vecLen_double = TENSEUR_SIMDVECLEN_DOUBLE;
 
 } // namespace ten
 

--- a/ten/expr.hxx
+++ b/ten/expr.hxx
@@ -8,432 +8,291 @@
 #include <ten/functional.hxx>
 #include <ten/types.hxx>
 
+namespace ten::details {
+
+// Input type
+template <class> struct input_type;
+
+template <class T> struct input_type<scalar<T>> {
+   using type = scalar<T>;
+};
+
+template <class T, class Shape, storage_order order, class Storage,
+          class Allocator>
+struct input_type<
+    ranked_tensor<T, Shape, order, Storage, Allocator>> {
+   using type = ranked_tensor<T, Shape, order, Storage, Allocator>;
+};
+
+template <class Input, class Output, template <typename...> class F,
+          class... Args>
+struct input_type<::ten::unary_expr<Input, Output, F, Args...>> {
+   using type = typename ::ten::unary_expr<Input, Output, F,
+                                           Args...>::input_type;
+};
+
+template <class Left, class Right, class Output,
+          template <typename...> class F, class... Args>
+struct input_type<
+    ::ten::binary_expr<Left, Right, Output, F, Args...>> {
+   using type = typename ::ten::binary_expr<Left, Right, Output, F,
+                                            Args...>::input_type;
+};
+
+// Output type
+template <class> struct output_type;
+
+template <class T> struct output_type<scalar<T>> {
+   using type = scalar<T>;
+};
+
+template <class T, class Shape, storage_order order, class Storage,
+          class Allocator>
+struct output_type<
+    ranked_tensor<T, Shape, order, Storage, Allocator>> {
+   using type = ranked_tensor<T, Shape, order, Storage, Allocator>;
+};
+
+template <class Input, class Output, template <typename...> class F,
+          class... Args>
+struct output_type<::ten::unary_expr<Input, Output, F, Args...>> {
+   using type = typename ::ten::unary_expr<Input, Output, F,
+                                           Args...>::output_type;
+};
+
+template <class Left, class Right, class Output,
+          template <typename...> class F, class... Args>
+struct output_type<
+    ::ten::binary_expr<Left, Right, Output, F, Args...>> {
+   using type = typename ::ten::binary_expr<Left, Right, Output, F,
+                                            Args...>::output_type;
+};
+
+// Input shape
+template<Tensor T>
+inline auto input_shape(const T& t) -> decltype(auto) {
+   return t.shape();
+}
+
+template<UnaryExpr ExprType>
+inline auto input_shape(const ExprType& expr) -> decltype(auto) {
+   return expr.value().shape();
+}
+
+template<BinaryExpr ExprType>
+inline auto input_shape(const ExprType& expr) -> decltype(auto) {
+   return expr.value().shape();
+}
+
+// Input value
+template<Tensor T>
+inline auto input_value(T& t) {return t;}
+
+template<UnaryExpr ExprType>
+inline auto input_value(ExprType& expr) {return expr.value();}
+
+template<BinaryExpr ExprType>
+inline auto input_value(ExprType& expr) {return expr.value();}
+
+}
+
 namespace ten {
 
-// FIXME This may be useful for getting Functional::Apply to work?
-// Keep it here for now. F is the function type or Inner Function type
-// Expression must accept a function_wrapper<...> or
-// function_wrapper<..>::outer_function_wrapper<...>
-template <template <class...> class f, class... args> struct function_wrapper {
-   template <template <template <class...> class /*F*/, class... /*Args*/>
-             class g>
-   struct outer_function_wrapper {};
-};
-
-namespace details {
-// Node shape
-template <class> struct node_wrapper;
-
-template <class __t> struct node_wrapper<scalar_node<__t>> {
-   static auto ptr(const std::shared_ptr<scalar_node<__t>> &node) {
-      return node.get();
-   }
-};
-
-template <class __t, class __shape, storage_order __order, class __storage,
-          class __allocator>
-struct node_wrapper<
-    tensor_node<__t, __shape, __order, __storage, __allocator>> {
-   static auto
-   shape(const std::shared_ptr<
-         tensor_node<__t, __shape, __order, __storage, __allocator>> &node) {
-      return node.get()->shape();
-   }
-   static auto
-   ptr(const std::shared_ptr<
-       tensor_node<__t, __shape, __order, __storage, __allocator>> &node) {
-      return node.get();
-   }
-};
-
-template <class __input, class __output, template <typename...> class __f,
-          typename... __args>
-struct node_wrapper<unary_node<__input, __output, __f, __args...>> {
-   static auto
-   shape(const std::shared_ptr<unary_node<__input, __output, __f, __args...>>
-             &node) {
-      return node.get()->node().get()->shape();
-   }
-   static auto
-   ptr(const std::shared_ptr<unary_node<__input, __output, __f, __args...>>
-           &node) {
-      return node.get()->node().get();
-   }
-};
-
-template <class __left, class __right, class __output,
-          template <typename...> class __f, typename... __args>
-struct node_wrapper<binary_node<__left, __right, __output, __f, __args...>> {
-   static auto
-   shape(const std::shared_ptr<
-         binary_node<__left, __right, __output, __f, __args...>> &node) {
-      return node.get()->node().get()->shape();
-   }
-   static auto
-   ptr(const std::shared_ptr<
-       binary_node<__left, __right, __output, __f, __args...>> &node) {
-      return node.get()->node().get();
-   }
-};
-} // namespace details
-
-namespace details {
-// Node type
-template <class> struct output_node_type;
-
-template <class __t> struct output_node_type<scalar_node<__t>> {
-   using type = scalar_node<__t>;
-};
-
-template <class __t, class __shape, storage_order __order, class __storage,
-          class __allocator>
-struct output_node_type<
-    tensor_node<__t, __shape, __order, __storage, __allocator>> {
-   using type = tensor_node<__t, __shape, __order, __storage, __allocator>;
-};
-
-template <class __input, class __output, template <typename...> class __f,
-          class... __args>
-struct output_node_type<::ten::unary_node<__input, __output, __f, __args...>> {
-   using type = typename ::ten::unary_node<__input, __output, __f,
-                                           __args...>::output_node_type;
-};
-
-template <class __left, class __right, class __output,
-          template <typename...> class __f, class... __args>
-struct output_node_type<
-    ::ten::binary_node<__left, __right, __output, __f, __args...>> {
-   using type = typename ::ten::binary_node<__left, __right, __output, __f,
-                                            __args...>::output_node_type;
-};
-} // namespace details
-
-// \class unary_node
-// Apply a function to a ten::Tensor or a ten::Scalar
-template <class __input, class __output, template <typename...> class __func,
-          typename... __args>
-class unary_node {
+// \class unary_expr
+// Apply a function to a tensor, column or row
+template <class Input, class Output, template <typename...> class Func,
+          typename... Args>
+class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
  public:
-   using input_node_type = typename details::output_node_type<__input>::type;
-   using output_node_type = __output;
-   using func_type = __func<input_node_type, __output>;
+   using input_type = typename ::ten::details::input_type<Input>::type;
+   using output_type = typename ::ten::details::output_type<Output>::type;
 
-   /// \typedef evaluated_type
-   /// Type of the evaluated expression
-   using evaluated_type = std::conditional_t<is_scalar_node<__output>::value,
-                                             typename __output::scalar_type,
-                                             typename __output::tensor_type>;
+   using func_type = Func<input_type, output_type>;
 
  private:
+   /// Flag for evaluated expression
+   bool _evaluated = false;
    /// Optional function type
    std::optional<func_type> _func = std::nullopt;
    //// Output value
-   std::shared_ptr<__output> _value = nullptr;
-   std::shared_ptr<__input> _input = nullptr;
+   Input _input;
+   Output _value;
 
  public:
-   unary_node() {}
+   unary_expr() {}
 
-   /// Construct a unary node if the function doesn't take additional parameters
-   unary_node(const std::shared_ptr<__input> &inp) noexcept
+   /// Construct a unary expr if the function doesn't take additional parameters
+   unary_expr(const Input &inp) noexcept
       requires(!::ten::functional::has_params<func_type>::value)
        : _input(inp), _func(func_type()) {}
 
-   /// Construct a unary node if the function take additional parameters.
+   /// Construct a unary expr if the function take additional parameters.
    /// The parameters of the functions fargs of type func_args are forwarded
    /// to the constructor of the function when necessary.
    template <typename... func_args>
-   unary_node(const std::shared_ptr<__input> &inp, func_args... fargs) noexcept
+   unary_expr(const Input &inp, func_args... fargs) noexcept
       requires(::ten::functional::has_params<func_type>::value)
        : _input(inp), _func(func_type(std::forward<func_args>(fargs)...)) {}
 
-   /// Returns a shared ptr to the output node
-   [[nodiscard]] inline std::shared_ptr<__output> node() { return _value; }
+   /// Returns a shared ptr to the output
+   /*[[nodiscard]] inline Output output() { return _value; }*/
 
    /// Returns whether the expression is evaluated
-   [[nodiscard]] bool evaluated() const { return _value.get(); }
+   [[nodiscard]] bool evaluated() const { return _evaluated; }
 
    /// Returns the evaluated expression of type ten::Scalar or ten::Tensor
-   [[nodiscard]] auto value() -> evaluated_type {
-      return evaluated_type(_value);
+   [[nodiscard]] auto value() const -> output_type {
+      return _value;
    }
 
-   /// Evaluated the expression
-   [[maybe_unused]] auto eval() noexcept -> evaluated_type {
-      if (_value)
-         return evaluated_type(_value);
+   /// Evaluate the expression
+   [[maybe_unused]] auto eval() noexcept -> output_type {
+      if (_evaluated)
+         return _value;
 
       // Evaluate input
-      if constexpr (::ten::is_unary_node<__input>::value ||
-                    ::ten::is_binary_node<__input>::value) {
-         if (!_input.get()->evaluated()) {
-            _input.get()->eval();
+      if constexpr (::ten::is_unary_expr<Input>::value ||
+                    ::ten::is_binary_expr<Input>::value) {
+         if (_input.evaluated()) {
+            _input.eval();
          }
       }
 
       // Allocate output
-      if constexpr (::ten::is_scalar_node<__output>::value) {
-         _value.reset(new __output());
-      } else if constexpr (!::ten::is_scalar_node<__output>::value &&
-                           __output::is_static()) {
-         _value.reset(new __output());
+      if constexpr (::ten::is_scalar<Output>::value) {
+         _value = Output();
+      } else if constexpr (!::ten::is_scalar<Output>::value &&
+                           Output::is_static()) {
+         _value = Output();
       } else {
          if constexpr (ten::functional::has_shape<func_type>::value) {
-            _value.reset(new __output(_func.value().output_shape(
-                ::ten::details::node_wrapper<__input>::shape(_input))));
+            _value = Output(_func.value().output_shape(::ten::details::input_shape(_input)));
          }
          if constexpr (!ten::functional::has_shape<func_type>::value) {
-            _value.reset(new __output(_func.value().output_shape(
-                ::ten::details::node_wrapper<__input>::shape(_input))));
+            _value = Output(_func.value().output_shape(::ten::details::input_shape(_input)));
          }
       }
 
       // Evaluate
-      _func.value()(*::ten::details::node_wrapper<__input>::ptr(_input),
-                    *_value.get());
-
-      return evaluated_type(_value);
+      _func.value()(::ten::details::input_value(_input), _value);
+      _evaluated = true;
+      return _value;
    }
 };
 
-/// \class unary_expr
-/// Unary expression.
-template <typename __expr, template <class...> class __func, typename... __args>
-class unary_expr : ::ten::expr<unary_expr<__expr, __func, __args...>> {
- public:
-   /// \typedef input_type
-   /// Type of the input type of the function
-   using input_node_type =
-       typename ::ten::details::output_node_type<__expr>::type;
-
-   /// \typedef output_type
-   /// Type of the output type of the function
-   using output_node_type = typename __func<input_node_type>::output_type;
-
-   /// \typedef node_type
-   /// Type of the node of the unary expresion
-   using node_type = unary_node<__expr, output_node_type, __func, __args...>;
-
-   /// \typedef expr_type
-   /// Type of the evaluated expression
-   using evaluated_type =
-       std::conditional_t<is_scalar_node<output_node_type>::value,
-                          typename output_node_type::scalar_type,
-                          typename output_node_type::tensor_type>;
-
-   using func_type = __func<input_node_type>;
-
- private:
-   /// Shared ptr to the node
-   std::shared_ptr<node_type> _node;
-
- public:
-   /// Construct a ten::unary_node from an expression
-   explicit unary_expr(const std::shared_ptr<__expr> &exp) noexcept
-      requires(!::ten::functional::has_params<func_type>::value)
-       : _node(std::make_shared<node_type>(exp)) {}
-
-   /// Construct a ten::unary_node from an expression with a parametric function
-   template <typename... func_args>
-   explicit unary_expr(const std::shared_ptr<__expr> &exp,
-                       func_args &&...fargs) noexcept
-      requires(::ten::functional::has_params<func_type>::value)
-       : _node(std::make_shared<node_type>(exp,
-                                           std::forward<func_args>(fargs)...)) {
-   }
-
-   // Returns the shared pointer to the node of the expression
-   [[nodiscard]] std::shared_ptr<node_type> node() const { return _node; }
-
-   /// Returns whether the expression is evaluated
-   [[nodiscard]] bool evaluated() const { return _node.get()->evaluated(); }
-
-   /// Returns the scalar or tensor value of the evaluated expression
-   [[nodiscard]] auto value() -> evaluated_type {
-      return evaluated_type(_node.get()->node());
-   }
-
-   /// Evaluate a unary expression
-   /// If the input expression has not been evaluated, it will evaluate it
-   /// recursively before evaluating this expression.
-   [[maybe_unused]] auto eval() -> evaluated_type {
-      return _node.get()->eval();
-   }
-};
-
-// \class binary_node
-// Node of a binary expresion
-// Left and Right can be scalar_node, tensor_node or binary_node
-template <class __left, class __right, class __output,
-          template <typename...> class __func, typename... __args>
-class binary_node {
+// \class binary_expr
+// Binary expresion
+// Left and Right can be scalar, tensor, row, column, unary_expr or binary_expr
+template <class Left, class Right, class Output,
+          template <typename...> class Func, typename... Args>
+class binary_expr {
  public:
    /// Left input type
-   using left_node_type = typename details::output_node_type<__left>::type;
+   using left_type = typename details::output_type<Left>::type;
 
    /// Right input type
-   using right_node_type = typename details::output_node_type<__right>::type;
+   using right_type = typename details::output_type<Right>::type;
 
    /// Output type
-   using output_node_type = __output;
+   using output_type = Output;
 
    using func_type =
-       __func<left_node_type, right_node_type, __output, __args...>;
+       Func<left_type, right_type, Output, Args...>;
    // using shape_type = typename Output::shape_type;
 
-   /// \typedef evaluated_type
-   /// Type of the evaluated expression
-   using evaluated_type = std::conditional_t<is_scalar_node<__output>::value,
-                                             typename __output::scalar_type,
-                                             typename __output::tensor_type>;
-
  private:
+   /// Flag for evaluated expression
+   bool _evaluated = false;
+   /// Function
    std::optional<func_type> _func = std::nullopt;
-   // std::optional<typename output::shape_type> _shape = std::nullopt;
-   std::shared_ptr<__output> _value = nullptr;
-   std::shared_ptr<__left> _left;
-   std::shared_ptr<__right> _right;
+   /// Left input
+   Left _left;
+   /// Right input
+   Right _right;
+   /// Output value
+   Output _value;
 
  public:
-   binary_node() {}
+   binary_expr() {}
 
-   binary_node(const std::shared_ptr<__left> &l,
-               const std::shared_ptr<__right> &r) noexcept
+   /// Construct a binary expr if the function doesn't take additional parameters
+   binary_expr(const Left &l, const Right &r) noexcept
       requires(!::ten::functional::has_params<func_type>::value)
        : _left(l), _right(r), _func(func_type()) {}
 
+   /// Construct a binary expr if the function take additional parameters.
+   /// The parameters of the functions fargs of type func_args are forwarded
+   /// to the constructor of the function when necessary.
    template <typename... func_args>
-   binary_node(const std::shared_ptr<__left> &l,
-               const std::shared_ptr<__right> &r, func_args... fargs) noexcept
+   binary_expr(const Left &l, const Right &r, func_args... fargs) noexcept
       requires(::ten::functional::has_params<func_type>::value)
        : _func(func_type(std::forward<func_args>(fargs)...)), _left(l),
          _right(r) {}
 
    /// Returns the shared ptr to the output node
-   [[nodiscard]] inline std::shared_ptr<__output> node() { return _value; }
+   //[[nodiscard]] inline std::shared_ptr<Output> node() { return _value; }
 
    /// Returns whether the expression is evaluated
-   [[nodiscard]] bool evaluated() const { return _value.get(); }
+   [[nodiscard]] bool evaluated() const { return _evaluated; }
 
-   /// Returns the the evaluated expression of type ten::Scalar of ten::Tensor
-   [[nodiscard]] auto value() -> evaluated_type {
-      return evaluated_type(_value);
-   }
-
-   [[maybe_unused]] auto eval() noexcept -> evaluated_type {
-      if (_value)
-         return evaluated_type(_value);
-
-      // Evaluate the left expr
-      if constexpr (::ten::is_unary_node<__left>::value ||
-                    ::ten::is_binary_node<__left>::value) {
-         if (!_left.get()->evaluated()) {
-            _left.get()->eval();
-         }
-      }
-
-      // Evaluate the right expr
-      if constexpr (::ten::is_unary_node<__right>::value ||
-                    ::ten::is_binary_node<__right>::value) {
-         if (!_right.get()->evaluated()) {
-            _right.get()->eval();
-         }
-      }
-
-      if constexpr (__output::is_static()) {
-         _value.reset(new __output());
-         // FIXME if right is unary node
-      } else if constexpr (::ten::is_unary_node<__left>::value) {
-         if constexpr (::ten::is_scalar_node<
-                           typename __left::evaluated_type::node_type>::value) {
-            _value.reset(new __output(func_type::output_shape(
-                ::ten::details::node_wrapper<__right>::shape(_right))));
-         }
-      } else {
-         // FIXME May requires using ten::functional::has_shape when
-         // a binary function has its own shape
-         if constexpr (!::ten::is_scalar_node<__left>::value &&
-                       !::ten::is_scalar_node<__right>::value) {
-            _value.reset(new __output(func_type::output_shape(
-                ::ten::details::node_wrapper<__left>::shape(_left),
-                ::ten::details::node_wrapper<__right>::shape(_right))));
-         }
-         if constexpr (::ten::is_scalar_node<__left>::value &&
-                       !::ten::is_scalar_node<__right>::value) {
-            _value.reset(new __output(func_type::output_shape(
-                ::ten::details::node_wrapper<__right>::shape(_right))));
-         }
-         if constexpr (!::ten::is_scalar_node<__left>::value &&
-                       ::ten::is_scalar_node<__right>::value) {
-            _value.reset(new __output(func_type::output_shape(
-                ::ten::details::node_wrapper<__left>::shape(_left))));
-         }
-      }
-
-      // Call the function
-      _func.value()(*details::node_wrapper<__left>::ptr(_left),
-                    *details::node_wrapper<__right>::ptr(_right),
-                    *_value.get());
-
-      return evaluated_type(_value);
-   }
-};
-
-/// \class binary_expr
-/// Binary expression
-// left and right can be scalar_node, tensor_node or binary_expr
-// left is std::shared_ptr<__left> and right is std::shared_ptr<__right>
-template <typename __left, typename __right,
-          template <typename...> class __func, typename... __args>
-class binary_expr
-    : ::ten::expr<binary_expr<__left, __right, __func, __args...>> {
- public:
-   /// Left input type
-   using left_node_type = typename details::output_node_type<__left>::type;
-
-   /// Right input type
-   using right_node_type = typename details::output_node_type<__right>::type;
-
-   /// output_node_type is scalar_node or tensor_node
-   using output_node_type =
-       typename __func<left_node_type, right_node_type>::output_type;
-
-   // Node type
-   using node_type =
-       binary_node<__left, __right, output_node_type, __func, __args...>;
-
-   /// \typedef evaluated_type
-   /// Type of the evaluated expression
-   using evaluated_type =
-       std::conditional_t<is_scalar_node<output_node_type>::value,
-                          typename output_node_type::scalar_type,
-                          typename output_node_type::tensor_type>;
-
- private:
-   std::shared_ptr<node_type> _node;
-
- public:
-   /// Construct a binary_expr from an expression
-   explicit binary_expr(const std::shared_ptr<__left> &l,
-                        const std::shared_ptr<__right> &r) noexcept
-       : _node(std::make_shared<node_type>(l, r)) {}
-
-   /// Returns a shared pointer to the node of the expression
-   [[nodiscard]] std::shared_ptr<node_type> node() const { return _node; }
-
-   /// Returns whether the expression is evaluated
-   [[nodiscard]] bool evaluated() const { return _node.get()->evaluated(); }
-
-   /// Returns the the evaluated expression of type ten::Scalar of ten::Tensor
-   [[nodiscard]] auto value() -> evaluated_type {
-      return evaluated_type(_node.get()->node());
+   /// Returns the the evaluated expression of type ten::Scalar or ten::Tensor
+   [[nodiscard]] auto value() -> output_type {
+      return _value;
    }
 
    /// Evaluate a binary expression
    /// If the input expression has not been evaluated, it will evaluate it
    /// recursively before evaluating this expression
-   [[maybe_unused]] auto eval() -> evaluated_type {
-      return _node.get()->eval();
+   [[maybe_unused]] auto eval() noexcept -> output_type {
+      if (_evaluated)
+         return _value;
+
+      // Evaluate the left expr
+      if constexpr (::ten::is_unary_expr<Left>::value ||
+                    ::ten::is_binary_expr<Left>::value) {
+         if (!_left.evaluated()) {
+            _left.eval();
+         }
+      }
+
+      // Evaluate the right expr
+      if constexpr (::ten::is_unary_expr<Right>::value ||
+                    ::ten::is_binary_expr<Right>::value) {
+         if (!_right.evaluated()) {
+            _right.eval();
+         }
+      }
+
+      if constexpr (Output::is_static()) {
+         _value = Output();
+         // FIXME if right is unary expr
+      } else if constexpr (::ten::is_unary_expr<Left>::value) {
+         if constexpr (::ten::is_scalar<Left>::value) {
+            _value = Output(func_type::output_shape(::ten::details::input_shape(_right)));
+         }
+      } else {
+         // FIXME May requires using ten::functional::has_shape when
+         // a binary function has its own shape
+         if constexpr (!::ten::is_scalar<Left>::value && !::ten::is_scalar<Right>::value) {
+            _value = Output(func_type::output_shape(
+                ::ten::details::input_shape(_left),
+                ::ten::details::input_shape(_right)));
+         }
+         if constexpr (::ten::is_scalar<Left>::value && !::ten::is_scalar<Right>::value) {
+            _value = Output(func_type::output_shape(::ten::details::input_shape(_right)));
+         }
+         if constexpr (!::ten::is_scalar<Left>::value && ::ten::is_scalar<Right>::value) {
+            _value = Output(func_type::output_shape(::ten::details::input_shape(_left)));
+         }
+      }
+
+      // Call the function
+      _func.value()(::ten::details::input_value(_left), ::ten::details::input_value(_right), _value);
+
+      // This expression has been evaluated
+      _evaluated = true;
+
+      return _value;
    }
 };
 

--- a/ten/expr.hxx
+++ b/ten/expr.hxx
@@ -19,24 +19,22 @@ template <class T> struct input_type<scalar<T>> {
 
 template <class T, class Shape, storage_order order, class Storage,
           class Allocator>
-struct input_type<
-    ranked_tensor<T, Shape, order, Storage, Allocator>> {
+struct input_type<ranked_tensor<T, Shape, order, Storage, Allocator>> {
    using type = ranked_tensor<T, Shape, order, Storage, Allocator>;
 };
 
 template <class Input, class Output, template <typename...> class F,
           class... Args>
 struct input_type<::ten::unary_expr<Input, Output, F, Args...>> {
-   using type = typename ::ten::unary_expr<Input, Output, F,
-                                           Args...>::input_type;
+   using type =
+       typename ::ten::unary_expr<Input, Output, F, Args...>::input_type;
 };
 
-template <class Left, class Right, class Output,
-          template <typename...> class F, class... Args>
-struct input_type<
-    ::ten::binary_expr<Left, Right, Output, F, Args...>> {
-   using type = typename ::ten::binary_expr<Left, Right, Output, F,
-                                            Args...>::input_type;
+template <class Left, class Right, class Output, template <typename...> class F,
+          class... Args>
+struct input_type<::ten::binary_expr<Left, Right, Output, F, Args...>> {
+   using type =
+       typename ::ten::binary_expr<Left, Right, Output, F, Args...>::input_type;
 };
 
 // Output type
@@ -48,56 +46,53 @@ template <class T> struct output_type<scalar<T>> {
 
 template <class T, class Shape, storage_order order, class Storage,
           class Allocator>
-struct output_type<
-    ranked_tensor<T, Shape, order, Storage, Allocator>> {
+struct output_type<ranked_tensor<T, Shape, order, Storage, Allocator>> {
    using type = ranked_tensor<T, Shape, order, Storage, Allocator>;
 };
 
 template <class Input, class Output, template <typename...> class F,
           class... Args>
 struct output_type<::ten::unary_expr<Input, Output, F, Args...>> {
-   using type = typename ::ten::unary_expr<Input, Output, F,
-                                           Args...>::output_type;
+   using type =
+       typename ::ten::unary_expr<Input, Output, F, Args...>::output_type;
 };
 
-template <class Left, class Right, class Output,
-          template <typename...> class F, class... Args>
-struct output_type<
-    ::ten::binary_expr<Left, Right, Output, F, Args...>> {
+template <class Left, class Right, class Output, template <typename...> class F,
+          class... Args>
+struct output_type<::ten::binary_expr<Left, Right, Output, F, Args...>> {
    using type = typename ::ten::binary_expr<Left, Right, Output, F,
                                             Args...>::output_type;
 };
 
 // Input shape
-template<Tensor T>
-inline auto input_shape(const T& t) -> decltype(auto) {
+template <Tensor T> inline auto input_shape(const T &t) -> decltype(auto) {
    return t.shape();
 }
 
-template<UnaryExpr ExprType>
-inline auto input_shape(const ExprType& expr) -> decltype(auto) {
+template <UnaryExpr ExprType>
+inline auto input_shape(const ExprType &expr) -> decltype(auto) {
    return expr.value().shape();
 }
 
-template<BinaryExpr ExprType>
-inline auto input_shape(const ExprType& expr) -> decltype(auto) {
+template <BinaryExpr ExprType>
+inline auto input_shape(const ExprType &expr) -> decltype(auto) {
    return expr.value().shape();
 }
 
 // Input value
-template<Scalar T>
-inline auto input_value(T& t) {return t;}
+template <Scalar T> inline auto input_value(T &t) { return t; }
 
-template<Tensor T>
-inline auto input_value(T& t) {return t;}
+template <Tensor T> inline auto input_value(T &t) { return t; }
 
-template<UnaryExpr ExprType>
-inline auto input_value(ExprType& expr) {return expr.value();}
-
-template<BinaryExpr ExprType>
-inline auto input_value(ExprType& expr) {return expr.value();}
-
+template <UnaryExpr ExprType> inline auto input_value(ExprType &expr) {
+   return expr.value();
 }
+
+template <BinaryExpr ExprType> inline auto input_value(ExprType &expr) {
+   return expr.value();
+}
+
+} // namespace ten::details
 
 namespace ten {
 
@@ -105,7 +100,7 @@ namespace ten {
 // Apply a function to a tensor, column or row
 template <class Input, class Output, template <typename...> class Func,
           typename... Args>
-class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
+class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>> {
  public:
    using input_type = typename ::ten::details::input_type<Input>::type;
    using output_type = typename ::ten::details::output_type<Output>::type;
@@ -144,9 +139,7 @@ class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
    [[nodiscard]] bool evaluated() const { return _evaluated; }
 
    /// Returns the evaluated expression of type ten::Scalar or ten::Tensor
-   [[nodiscard]] auto value() const -> output_type {
-      return _value;
-   }
+   [[nodiscard]] auto value() const -> output_type { return _value; }
 
    /// Evaluate the expression
    [[maybe_unused]] auto eval() noexcept -> output_type {
@@ -169,10 +162,12 @@ class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
          _value = Output();
       } else {
          if constexpr (ten::functional::has_shape<func_type>::value) {
-            _value = Output(_func.value().output_shape(::ten::details::input_shape(_input)));
+            _value = Output(_func.value().output_shape(
+                ::ten::details::input_shape(_input)));
          }
          if constexpr (!ten::functional::has_shape<func_type>::value) {
-            _value = Output(_func.value().output_shape(::ten::details::input_shape(_input)));
+            _value = Output(_func.value().output_shape(
+                ::ten::details::input_shape(_input)));
          }
       }
 
@@ -191,7 +186,7 @@ class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
 // Left and Right can be scalar, tensor, row, column, unary_expr or binary_expr
 template <class Left, class Right, class Output,
           template <typename...> class Func, typename... Args>
-class binary_expr {
+class binary_expr : ten::expr<binary_expr<Left, Right, Output, Func, Args...>> {
  public:
    /// Left input type
    using left_type = typename details::output_type<Left>::type;
@@ -202,8 +197,7 @@ class binary_expr {
    /// Output type
    using output_type = Output;
 
-   using func_type =
-       Func<left_type, right_type, Output, Args...>;
+   using func_type = Func<left_type, right_type, Output, Args...>;
    // using shape_type = typename Output::shape_type;
 
  private:
@@ -221,7 +215,8 @@ class binary_expr {
  public:
    binary_expr() {}
 
-   /// Construct a binary expr if the function doesn't take additional parameters
+   /// Construct a binary expr if the function doesn't take additional
+   /// parameters
    binary_expr(const Left &l, const Right &r) noexcept
       requires(!::ten::functional::has_params<func_type>::value)
        : _left(l), _right(r), _func(func_type()) {}
@@ -242,9 +237,7 @@ class binary_expr {
    [[nodiscard]] bool evaluated() const { return _evaluated; }
 
    /// Returns the the evaluated expression of type ten::Scalar or ten::Tensor
-   [[nodiscard]] auto value() -> output_type {
-      return _value;
-   }
+   [[nodiscard]] auto value() const -> output_type { return _value; }
 
    /// Evaluate a binary expression
    /// If the input expression has not been evaluated, it will evaluate it
@@ -271,29 +264,116 @@ class binary_expr {
 
       if constexpr (Output::is_static()) {
          _value = Output();
-         // FIXME if right is unary expr
-      } else if constexpr (::ten::is_unary_expr<Left>::value) {
-         if constexpr (::ten::is_scalar<Left>::value) {
-            _value = Output(func_type::output_shape(::ten::details::input_shape(_right)));
+      } else if constexpr (::ten::is_unary_expr<Left>::value &&
+                           ::ten::is_unary_expr<Right>::value) {
+         // Left and Right are unary_expr
+         // They can't be both scalars
+         if constexpr (::ten::is_scalar<left_type>::value &&
+                       !::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_right)));
+         }
+         if constexpr (!::ten::is_scalar<left_type>::value &&
+                       ::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left)));
+         }
+         if constexpr (!::ten::is_scalar<left_type>::value &&
+                       !::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
+         }
+      } else if constexpr (::ten::is_binary_expr<Left>::value &&
+                           ::ten::is_binary_expr<Right>::value) {
+         // Left and Right are binary_expr
+         if constexpr (::ten::is_scalar<left_type>::value &&
+                       !::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_right)));
+         }
+         if constexpr (!::ten::is_scalar<left_type>::value &&
+                       ::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left)));
+         }
+         if constexpr (!::ten::is_scalar<left_type>::value &&
+                       !::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
+         }
+      } else if constexpr (::ten::is_unary_expr<Left>::value &&
+                           !::ten::is_unary_expr<Right>::value &&
+                           !::ten::is_binary_expr<Right>::value) {
+         // Left is unary expr and right is tensor or scalar
+         if constexpr (::ten::is_scalar<left_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_right)));
+         } else {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
+         }
+      } else if constexpr (::ten::is_binary_expr<Left>::value &&
+                           !ten::is_unary_expr<Right>::value &&
+                           !::ten::is_binary_expr<Right>::value) {
+         // Left is binary expr and right is tensor or scalar
+         if constexpr (::ten::is_scalar<left_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_right)));
+         } else {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
+         }
+      } else if constexpr (!::ten::is_unary_expr<Left>::value &&
+                           !::ten::is_binary_expr<Left>::value &&
+                           ::ten::is_unary_expr<Right>::value) {
+         // Left is tensor or scalar and Right is unary_expr
+         if constexpr (::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left)));
+         } else {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
+         }
+      } else if constexpr (!::ten::is_unary_expr<Left>::value &&
+                           !::ten::is_binary_expr<Left>::value &&
+                           ten::is_binary_expr<Right>::value) {
+         // Left is tensor or scalar and right is binary_expr
+         if constexpr (::ten::is_scalar<right_type>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left)));
+         } else {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
          }
       } else {
-         // FIXME May requires using ten::functional::has_shape when
-         // a binary function has its own shape
-         if constexpr (!::ten::is_scalar<Left>::value && !::ten::is_scalar<Right>::value) {
-            _value = Output(func_type::output_shape(
-                ::ten::details::input_shape(_left),
-                ::ten::details::input_shape(_right)));
+         // Left and right are both tensor or scalar
+         if constexpr (!::ten::is_scalar<Left>::value &&
+                       !::ten::is_scalar<Right>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left),
+                                        ::ten::details::input_shape(_right)));
          }
-         if constexpr (::ten::is_scalar<Left>::value && !::ten::is_scalar<Right>::value) {
-            _value = Output(func_type::output_shape(::ten::details::input_shape(_right)));
+         if constexpr (::ten::is_scalar<Left>::value &&
+                       !::ten::is_scalar<Right>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_right)));
          }
-         if constexpr (!::ten::is_scalar<Left>::value && ::ten::is_scalar<Right>::value) {
-            _value = Output(func_type::output_shape(::ten::details::input_shape(_left)));
+         if constexpr (!::ten::is_scalar<Left>::value &&
+                       ::ten::is_scalar<Right>::value) {
+            _value = Output(
+                func_type::output_shape(::ten::details::input_shape(_left)));
          }
       }
 
       // Call the function
-      _func.value()(::ten::details::input_value(_left), ::ten::details::input_value(_right), _value);
+      _func.value()(::ten::details::input_value(_left),
+                    ::ten::details::input_value(_right), _value);
 
       // This expression has been evaluated
       _evaluated = true;

--- a/ten/expr.hxx
+++ b/ten/expr.hxx
@@ -85,6 +85,9 @@ inline auto input_shape(const ExprType& expr) -> decltype(auto) {
 }
 
 // Input value
+template<Scalar T>
+inline auto input_value(T& t) {return t;}
+
 template<Tensor T>
 inline auto input_value(T& t) {return t;}
 

--- a/ten/expr.hxx
+++ b/ten/expr.hxx
@@ -153,7 +153,7 @@ class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
       // Evaluate input
       if constexpr (::ten::is_unary_expr<Input>::value ||
                     ::ten::is_binary_expr<Input>::value) {
-         if (_input.evaluated()) {
+         if (!_input.evaluated()) {
             _input.eval();
          }
       }
@@ -175,7 +175,10 @@ class unary_expr : ten::expr<unary_expr<Input, Output, Func, Args...>>{
 
       // Evaluate
       _func.value()(::ten::details::input_value(_input), _value);
+
+      // This expression has been evaluated
       _evaluated = true;
+
       return _value;
    }
 };

--- a/ten/functional.hxx
+++ b/ten/functional.hxx
@@ -22,20 +22,21 @@ template <class, class> struct common_type;
 
 // Tensor, Tensor
 template <Tensor A, Tensor B>
-   requires(same_shape<A, B> && same_storage_order<A, B> && same_storage<A, B> && same_allocator<A, B>)
+   requires(same_shape<A, B> && same_storage_order<A, B> &&
+            same_storage<A, B> && same_allocator<A, B>)
 struct common_type<A, B> {
    using value_type =
        std::common_type_t<typename A::value_type, typename B::value_type>;
    using type =
        ranked_tensor<value_type, typename A::shape_type, A::storage_order(),
-                   typename A::storage_type, typename A::allocator_type>;
+                     typename A::storage_type, typename A::allocator_type>;
 };
 
 // Scalar, Tensor
 template <Scalar A, Tensor B>
 //   requires(::ten::same_value_type<A, B>)
 struct common_type<A, B> {
-   using type =B;
+   using type = B;
 };
 
 // Tensor, Scalar
@@ -48,7 +49,6 @@ struct common_type<A, B> {
 template <class A, class B>
 using common_type_t = typename common_type<A, B>::type;
 
-
 template <class, class> struct mul_result;
 
 template <class A, class B>
@@ -56,40 +56,42 @@ using mul_result_t = typename mul_result<A, B>::type;
 
 // vector * vector
 template <Vector A, Vector B>
-requires(same_shape<A, B> && same_storage_order<A, B> &&
+   requires(same_shape<A, B> && same_storage_order<A, B> &&
             same_storage<A, B> && same_allocator<A, B>)
 struct mul_result<A, B> {
    using value_type =
        std::common_type_t<typename A::value_type, typename B::value_type>;
    using type =
        ranked_tensor<value_type, typename A::shape_type, A::storage_order(),
-                   typename A::storage_type, typename A::allocator_type>;
+                     typename A::storage_type, typename A::allocator_type>;
 };
 
 // matrix * matrix
 template <Matrix A, Matrix B>
-requires(same_storage_order<A, B> && same_storage<A, B> && same_allocator<A, B>)
+   requires(same_storage_order<A, B> && same_storage<A, B> &&
+            same_allocator<A, B>)
 struct mul_result<A, B> {
    using value_type =
        std::common_type_t<typename A::value_type, typename B::value_type>;
    using type =
        ranked_tensor<value_type,
-                   ::ten::shape<A::shape_type::template static_dim<0>(),
-                                B::shape_type::template static_dim<1>()>,
-                   A::storage_order(), typename A::storage_type,
-                   typename A::allocator_type>;
+                     ::ten::shape<A::shape_type::template static_dim<0>(),
+                                  B::shape_type::template static_dim<1>()>,
+                     A::storage_order(), typename A::storage_type,
+                     typename A::allocator_type>;
 };
 
 // matrix * vector
 template <Matrix A, Vector B>
-   requires(same_storage_order<A, B> && same_storage<A, B> && same_allocator<A, B>)
+   requires(same_storage_order<A, B> && same_storage<A, B> &&
+            same_allocator<A, B>)
 struct mul_result<A, B> {
    using value_type =
        std::common_type_t<typename A::value_type, typename B::value_type>;
    using type =
        ranked_tensor<value_type, shape<A::shape_type::template static_dim<0>()>,
-                   A::storage_order(), typename A::storage_type,
-                   typename A::allocator_type>;
+                     A::storage_order(), typename A::storage_type,
+                     typename A::allocator_type>;
 };
 
 // scalar * tensor
@@ -97,7 +99,6 @@ template <Scalar A, Tensor B> struct mul_result<A, B> {
    using type = B;
 };
 
-/*
 /// scalar * unary_expr
 template <Scalar A, UnaryExpr B> struct mul_result<A, B> {
    using type = std::remove_cvref_t<B>::output_type;
@@ -106,60 +107,55 @@ template <Scalar A, UnaryExpr B> struct mul_result<A, B> {
 /// scalar * binary_expr
 template <Scalar A, BinaryExpr B> struct mul_result<A, B> {
    using type = std::remove_cvref_t<B>::output_type;
-};*/
+};
 
-
-/// node * vector
-/*template <Node A, VectorNode B> struct mul_result<A, B> {
-   using evaluated_type = std::remove_cvref_t<A>::evaluated_type::node_type;
-   using value_type = mul_result<evaluated_type, B>::value_type;
+/// UnaryExpr * vector
+template <UnaryExpr A, Vector B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
    using type = mul_result<evaluated_type, B>::type;
-};*/
+};
 
-/// matrix_node * matrix
-/*template <Node A, MatrixNode B>
-   requires(
-       ten::is_matrix_node<
-           typename std::remove_cvref_t<A>::evaluated_type::node_type>::value)
-struct mul_result<A, B> {
-   using evaluated_type = std::remove_cvref_t<A>::evaluated_type::node_type;
-   using value_type = mul_result<evaluated_type, B>::value_type;
+/// BinaryExpr * vector
+template <BinaryExpr A, Vector B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
    using type = mul_result<evaluated_type, B>::type;
-};*/
+};
 
-/// scalar_node * tensor
-/*template <Node A, TensorNode B>
-   requires(
-       ten::is_scalar_node<
-           typename std::remove_cvref_t<A>::evaluated_type::node_type>::value)
-struct mul_result<A, B> {
-   // using evaluated_type =
-   // std::remove_cvref_t<A>::evaluated_type::node_type; using value_type =
-   // mul_result<evaluated_type, B>::value_type;
-   using type = B; // mul_result<evaluated_type, B>::type;
-};*/
+/// UnaryExpr * matrix
+template <UnaryExpr A, Matrix B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
+   using type = mul_result<evaluated_type, B>::type;
+};
 
-/// vector * node
-/*template <VectorNode A, Node B> struct mul_result<A, B> {
-   using evaluated_type = std::remove_cvref_t<B>::evaluated_type::node_type;
-   using value_type = mul_result<evaluated_type, A>::value_type;
+/// matrix * UnaryExpr
+template <Matrix A, UnaryExpr B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<B>::output_type;
    using type = mul_result<evaluated_type, A>::type;
-};*/
+};
 
-/// matrix * node
-/*template <MatrixNode A, Node B> struct mul_result<A, B> {
-   using evaluated_type = std::remove_cvref_t<B>::evaluated_type::node_type;
-   using value_type = mul_result<evaluated_type, A>::value_type;
+/// BinaryExpr * Matrix
+template <BinaryExpr A, Matrix B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
+   using type = mul_result<evaluated_type, B>::type;
+};
+
+/// Matrix * BinaryExpr
+template <Matrix A, BinaryExpr B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<B>::output_type;
    using type = mul_result<evaluated_type, A>::type;
-};*/
+};
 
-/// tensor * node
-/*template <TensorNode A, Node B> struct mul_result<A, B> {
-   using evaluated_type = std::remove_cvref_t<B>::evaluated_type::node_type;
-   using value_type = mul_result<evaluated_type, A>::value_type;
-   using type = mul_result<evaluated_type, A>::type;
-};*/
+/// UnaryExpr * tensor
+template <UnaryExpr A, Tensor B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
+   using type = mul_result<evaluated_type, B>::type;
+};
 
+/// BinaryExpr * tensor
+template <BinaryExpr A, Tensor B> struct mul_result<A, B> {
+   using evaluated_type = std::remove_cvref_t<A>::output_type;
+   using type = mul_result<evaluated_type, B>::type;
+};
 
 // dynamic reshape result
 template <class A, class Shape> struct reshape_result {
@@ -208,7 +204,9 @@ template <class Func> struct has_shape {
 
 /// Square root
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct sqrt : func<> {
    using output_type = B;
 
@@ -227,7 +225,9 @@ struct sqrt : func<> {
 
 /// Square
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct sqr : func<> {
    using output_type = B;
 
@@ -246,8 +246,10 @@ struct sqr : func<> {
 
 /// absolute value
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
-struct abs : func<>{
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
+struct abs : func<> {
    using output_type = B;
 
    void operator()(const A &a, B &b) {
@@ -265,7 +267,9 @@ struct abs : func<>{
 
 /// Power
 template <class A, class B>
-requires ((ten::is_tensor<A>::value || ten::is_column<A>::value || ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((ten::is_tensor<A>::value || ten::is_column<A>::value ||
+             ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct pow : func<true> {
  private:
    double _n;
@@ -290,7 +294,9 @@ struct pow : func<true> {
 
 /// Minimum
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_scalar<B>::value)
 struct min : func<> {
    using output_type = B;
 
@@ -303,15 +309,17 @@ struct min : func<> {
       b = res;
    }
 
-   static typename B::shape_type
-   output_shape(const typename B::shape_type &right) {
-      return right;
+   static typename A::shape_type
+   output_shape(const typename A::shape_type &left) {
+      return left;
    }
 };
 
 /// Maximum
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_scalar<B>::value)
 struct max : func<> {
    using output_type = B;
 
@@ -324,14 +332,16 @@ struct max : func<> {
       b = res;
    }
 
-   static typename B::shape_type
-   output_shape(const typename B::shape_type &right) {
-      return right;
+   static typename A::shape_type
+   output_shape(const typename A::shape_type &left) {
+      return left;
    }
 };
 /// Sum
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_scalar<B>::value)
 struct sum : func<> {
    using output_type = B;
 
@@ -352,7 +362,9 @@ struct sum : func<> {
 
 /// Cumulative sum
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct cum_sum : func<> {
    using output_type = B;
 
@@ -372,7 +384,9 @@ struct cum_sum : func<> {
 
 /// Prod
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_scalar<B>::value)
 struct prod : func<> {
    using output_type = B;
 
@@ -385,9 +399,9 @@ struct prod : func<> {
       b = res;
    }
 
-   static typename B::shape_type
-   output_shape(const typename B::shape_type &right) {
-      return right;
+   static typename A::shape_type
+   output_shape(const typename A::shape_type &left) {
+      return left;
    }
 };
 
@@ -395,7 +409,9 @@ struct prod : func<> {
 
 /// Sine
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct sin : func<> {
    using output_type = B;
 
@@ -414,7 +430,9 @@ struct sin : func<> {
 
 /// asin
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct asin : func<> {
    using output_type = B;
 
@@ -433,7 +451,9 @@ struct asin : func<> {
 
 /// Sinh
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct sinh : func<> {
    using output_type = B;
 
@@ -452,7 +472,9 @@ struct sinh : func<> {
 
 /// Cosine
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct cos : func<> {
    using output_type = B;
 
@@ -471,7 +493,9 @@ struct cos : func<> {
 
 /// acos
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct acos : func<> {
    using output_type = B;
 
@@ -490,7 +514,9 @@ struct acos : func<> {
 
 /// cosh
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct cosh : func<> {
    using output_type = B;
 
@@ -509,7 +535,9 @@ struct cosh : func<> {
 
 /// Tangent
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct tan : func<> {
    using output_type = B;
 
@@ -527,7 +555,9 @@ struct tan : func<> {
 };
 
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct atan : func<> {
    using output_type = B;
 
@@ -545,7 +575,9 @@ struct atan : func<> {
 };
 
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct tanh : func<> {
    using output_type = B;
 
@@ -564,7 +596,9 @@ struct tanh : func<> {
 
 /// Exponential
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct exp : func<> {
    using output_type = B;
 
@@ -583,7 +617,9 @@ struct exp : func<> {
 
 /// Natural logarithm
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct log : func<> {
    using output_type = B;
 
@@ -602,7 +638,9 @@ struct log : func<> {
 
 /// Logarithm
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct log10 : func<> {
    using output_type = B;
 
@@ -621,7 +659,9 @@ struct log10 : func<> {
 
 /// Floor
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct floor : func<> {
    using output_type = B;
 
@@ -640,7 +680,9 @@ struct floor : func<> {
 
 /// Ceil
 template <class A, class B>
-requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+   requires((::ten::is_tensor<A>::value || ::ten::is_column<A>::value ||
+             ::ten::is_row<A>::value) &&
+            ::ten::is_tensor<B>::value)
 struct ceil : func<> {
    using output_type = B;
 
@@ -656,7 +698,6 @@ struct ceil : func<> {
       return right;
    }
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // Binary functions (Add, Sub, Mul and Div)
@@ -694,14 +735,16 @@ template <::ten::binary_operation Kind> struct scalar_left_binary_func {
       using output_type = C;
 
       static constexpr typename C::shape_type
-      output_shape(//const typename A::shape_type &left,
-                   const typename B::shape_type &right) {
+      output_shape( // const typename A::shape_type &left,
+          const typename B::shape_type &right) {
          // FIXME Maybe check that left == right
          typename C::shape_type s(right);
          return s;
       }
 
-      static auto output_shape(/*const A &a, */const B &b) { return b.shape(); }
+      static auto output_shape(/*const A &a, */ const B &b) {
+         return b.shape();
+      }
 
       void operator()(const A &left, const B &right, C &result) {
          /// FIXME use broadcast
@@ -731,8 +774,7 @@ template <::ten::binary_operation Kind> struct scalar_right_binary_func {
       using output_type = C;
 
       static constexpr typename C::shape_type
-      output_shape(const typename A::shape_type &left)
-      {
+      output_shape(const typename A::shape_type &left) {
          typename C::shape_type s(left);
          return s;
       }
@@ -758,22 +800,19 @@ template <::ten::binary_operation Kind> struct scalar_right_binary_func {
    };
 };
 
-
 template <class A, class B, class C>
 // = typename details::mul_result<A, B>::type>
 struct mul;
 
 // vector * vector
-template <Vector X, Vector Y, Vector Z>
-struct mul<X, Y, Z> {
+template <Vector X, Vector Y, Vector Z> struct mul<X, Y, Z> {
 
    template <Vector A, Vector B, Vector C>
    using func = binary_func<::ten::binary_operation::mul>::func<A, B, C>;
 };
 
 // matrix * matrix
-template <Matrix X, Matrix Y, Matrix Z>
-struct mul<X, Y, Z> {
+template <Matrix X, Matrix Y, Matrix Z> struct mul<X, Y, Z> {
 
    template <Matrix A, Matrix B, Matrix C>
    struct func : ::ten::functional::func<> {
@@ -794,8 +833,7 @@ struct mul<X, Y, Z> {
 };
 
 // matrix * vector
-template <Matrix X, Vector Y, Vector Z>
-struct mul<X, Y, Z> {
+template <Matrix X, Vector Y, Vector Z> struct mul<X, Y, Z> {
 
    template <Matrix A, Vector B, Vector C>
    struct func : ::ten::functional::func<> {
@@ -816,8 +854,7 @@ struct mul<X, Y, Z> {
 };
 
 // scalar * tensor
-template <Scalar X, Tensor Y, Tensor Z>
-struct mul<X, Y, Z> {
+template <Scalar X, Tensor Y, Tensor Z> struct mul<X, Y, Z> {
 
    template <Scalar A, Tensor B, Tensor C>
    struct func : ::ten::functional::func<> {
@@ -843,8 +880,8 @@ struct mul<X, Y, Z> {
 template <UnaryExpr X, Matrix Y, Matrix Z>
 // FIXME REquire X::output_type to be a matrix
 struct mul<X, Y, Z> {
-   //using evaluated_type = std::remove_cvref_t<X>::output_type;
-   // matrix * matrix
+   // using evaluated_type = std::remove_cvref_t<X>::output_type;
+   //  matrix * matrix
    template <Matrix A, Matrix B, Matrix C>
    using func = mul<A, B, C>::template func<A, B, C>;
 };
@@ -853,8 +890,8 @@ struct mul<X, Y, Z> {
 template <BinaryExpr X, Matrix Y, Matrix Z>
 // FIXME REquire X::output_type to be a matrix
 struct mul<X, Y, Z> {
-   //using evaluated_type = std::remove_cvref_t<X>::output_type;
-   // matrix * matrix
+   // using evaluated_type = std::remove_cvref_t<X>::output_type;
+   //  matrix * matrix
    template <Matrix A, Matrix B, Matrix C>
    using func = mul<A, B, C>::template func<A, B, C>;
 };
@@ -871,18 +908,16 @@ struct mul<X, Y, Z> {
 /// Other BLAS functions
 
 // C <- alpha * X * Y + beta * C
-/*template<class A, class B, class C, class D = typename ::ten::functional::details::mul_result<A, B>::type>
-class gemm : ::ten::functional::func<true> {
-private:
-   T _alpha;
-   T _beta;
-public:
-   gemm(const T alpha, const T beta) : _alpha(alpha), _beta(beta) {}
+/*template<class A, class B, class C, class D = typename
+::ten::functional::details::mul_result<A, B>::type> class gemm :
+::ten::functional::func<true> { private: T _alpha; T _beta; public: gemm(const T
+alpha, const T beta) : _alpha(alpha), _beta(beta) {}
 
    using output_type = C;
 
-   static constexpr typename C::shape_type 
-   output_shape(const typename A::shape_type& left, const typename B::shape_type& right) {
+   static constexpr typename C::shape_type
+   output_shape(const typename A::shape_type& left, const typename
+B::shape_type& right) {
    }
 
    void operator()(const A& a, const B& b, C& result) {
@@ -924,13 +959,10 @@ struct __axpy2 : ::ten::functional::func<> {
 template <class Shape> struct static_reshape {
    static_assert(Shape::is_static(), "Shape must be static");
 
-   template <class A, class B>
-   struct func : ::ten::functional::func<> {
+   template <class A, class B> struct func : ::ten::functional::func<> {
       using output_type = B;
 
-      void operator()(const A &left, B &right) {
-         right = B(left.node());
-      }
+      void operator()(const A &left, B &right) { right = B(left.node()); }
    };
 };
 
@@ -971,8 +1003,7 @@ template <class Shape> struct static_transpose {
    static_assert(Shape::is_static(), "Shape must be static.");
    static_assert(Shape::rank() == 2, "Shape rank must be 2.");
 
-   template <class A, class B>
-   struct func : ::ten::functional::func<> {
+   template <class A, class B> struct func : ::ten::functional::func<> {
       using output_type = B;
 
       void operator()(const A &left, B &right) {
@@ -1002,8 +1033,7 @@ using DimsStaticTranspose = StaticTranspose<::ten::Shape<cols, rows>>;*/
 // Dynamic transpose
 template <class Shape> struct dynamic_transpose {
 
-   template <class A, class B>
-   struct func : ::ten::functional::func<true> {
+   template <class A, class B> struct func : ::ten::functional::func<true> {
       static_assert(Shape::is_dynamic(), "Shape must be dynamic");
       // FIXME Currently defined only for matrices
       static_assert(Shape::rank() == 2, "Shape rank must be 2.");

--- a/ten/functional.hxx
+++ b/ten/functional.hxx
@@ -78,10 +78,10 @@ struct mul_result<A, B> {
 };
 
 // scalar * tensor
-//template <Scalar A, Tensor B> struct mul_result<A, B> {
-// using value_type = typename B::value_type;
-//   using type = B;
-//};
+template <Scalar A, Tensor B> struct mul_result<A, B> {
+   //using value_type = typename B::value_type;
+   using type = B;
+};
 
 /// scalar * unary_expr
 /*template <Scalar A, UnaryExpr B> struct mul_result<A, B> {
@@ -263,11 +263,12 @@ struct min : func<> {
 };
 
 /// Maximum
-template <class __a, class B = typename __a::scalarnode_type>
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
 struct max : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       type res = a[0];
       for (size_t i = 1; i < a.size(); i++) {
@@ -282,11 +283,12 @@ struct max : func<> {
    }
 };
 /// Sum
-template <class __a, class B = typename __a::scalarnode_type>
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
 struct sum : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       type res = 0.;
       for (size_t i = 0; i < a.size(); i++) {
@@ -301,11 +303,13 @@ struct sum : func<> {
    }
 };
 
-/// cum__Sum
-template <class __a, class B = __a> struct cum_sum : func<> {
+/// Cumulative sum
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct cum_sum : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       b[0] = static_cast<type>(a[0]);
       for (size_t i = 1; i < a.size(); i++) {
@@ -320,11 +324,12 @@ template <class __a, class B = __a> struct cum_sum : func<> {
 };
 
 /// Prod
-template <class __a, class B = typename __a::scalarnode_type>
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_scalar<B>::value)
 struct prod : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       type res = 1.;
       for (size_t i = 0; i < a.size(); i++) {
@@ -342,10 +347,12 @@ struct prod : func<> {
 // TODO use simd for cos, sin and tan
 
 /// Sine
-template <class __a, class B = __a> struct sin : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct sin : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::sin(static_cast<type>(a[i]));
@@ -359,10 +366,12 @@ template <class __a, class B = __a> struct sin : func<> {
 };
 
 /// asin
-template <class __a, class B = __a> struct asin : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct asin : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::asin(static_cast<type>(a[i]));
@@ -376,10 +385,12 @@ template <class __a, class B = __a> struct asin : func<> {
 };
 
 /// Sinh
-template <class __a, class B = __a> struct sinh : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct sinh : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::sinh(static_cast<type>(a[i]));
@@ -393,10 +404,12 @@ template <class __a, class B = __a> struct sinh : func<> {
 };
 
 /// Cosine
-template <class __a, class B = __a> struct cos : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct cos : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::cos(static_cast<type>(a[i]));
@@ -410,10 +423,12 @@ template <class __a, class B = __a> struct cos : func<> {
 };
 
 /// acos
-template <class __a, class B = __a> struct acos : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct acos : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::acos(static_cast<type>(a[i]));
@@ -427,10 +442,12 @@ template <class __a, class B = __a> struct acos : func<> {
 };
 
 /// cosh
-template <class __a, class B = __a> struct cosh : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct cosh : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::cosh(static_cast<type>(a[i]));
@@ -444,10 +461,12 @@ template <class __a, class B = __a> struct cosh : func<> {
 };
 
 /// Tangent
-template <class __a, class B = __a> struct tan : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct tan : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::tan(static_cast<type>(a[i]));
@@ -460,10 +479,12 @@ template <class __a, class B = __a> struct tan : func<> {
    }
 };
 
-template <class __a, class B = __a> struct atan : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct atan : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::atan(static_cast<type>(a[i]));
@@ -476,10 +497,12 @@ template <class __a, class B = __a> struct atan : func<> {
    }
 };
 
-template <class __a, class B = __a> struct tanh : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct tanh : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::tanh(static_cast<type>(a[i]));
@@ -493,10 +516,12 @@ template <class __a, class B = __a> struct tanh : func<> {
 };
 
 /// Exponential
-template <class __a, class B = __a> struct exp : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct exp : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::exp(static_cast<type>(a[i]));
@@ -510,10 +535,12 @@ template <class __a, class B = __a> struct exp : func<> {
 };
 
 /// Natural logarithm
-template <class __a, class B = __a> struct log : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct log : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::log(static_cast<type>(a[i]));
@@ -527,10 +554,12 @@ template <class __a, class B = __a> struct log : func<> {
 };
 
 /// Logarithm
-template <class __a, class B = __a> struct log10 : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct log10 : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::log10(static_cast<type>(a[i]));
@@ -544,10 +573,12 @@ template <class __a, class B = __a> struct log10 : func<> {
 };
 
 /// Floor
-template <class __a, class B = __a> struct floor : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct floor : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::floor(static_cast<type>(a[i]));
@@ -561,10 +592,12 @@ template <class __a, class B = __a> struct floor : func<> {
 };
 
 /// Ceil
-template <class __a, class B = __a> struct ceil : func<> {
+template <class A, class B>
+requires ((::ten::is_tensor<A>::value || ::ten::is_column<A>::value || ::ten::is_row<A>::value) && ::ten::is_tensor<B>::value)
+struct ceil : func<> {
    using output_type = B;
 
-   void operator()(const __a &a, B &b) {
+   void operator()(const A &a, B &b) {
       using type = typename B::value_type;
       for (size_t i = 0; i < a.size(); i++) {
          b[i] = std::ceil(static_cast<type>(a[i]));
@@ -663,7 +696,6 @@ struct mul<X, Y, Z> {
 };
 
 // scalar * tensor
-/*
 template <Scalar X, Tensor Y, Tensor Z>
 struct mul<X, Y, Z> {
 
@@ -685,7 +717,7 @@ struct mul<X, Y, Z> {
          }
       }
    };
-};*/
+};
 
 // matrix_node * matrix
 /*template <Node __x, MatrixNode __y, MatrixNode __z>

--- a/ten/io
+++ b/ten/io
@@ -1,0 +1,7 @@
+#ifndef TENSEUR_IO
+#define TENSEUR_IO
+
+#include <ten/ios/serialization.hxx>
+#include <ten/ios/mtx.hxx>
+
+#endif

--- a/ten/ios/mtx.hxx
+++ b/ten/ios/mtx.hxx
@@ -1,0 +1,71 @@
+#ifndef TENSUER_IOS_MTX
+#define TENSUER_IOS_MTX
+
+#include <ten/tensor.hxx>
+
+namespace ten::io {
+
+// Save vector to a file
+template <class T>
+   requires(::ten::is_vector<T>::value &&
+            std::is_floating_point_v<typename T::value_type>)
+void save_mtx(const T &t, std::string filename) {
+   std::cout << "Tenseur: Saving vector to file " << filename << std::endl;
+   if (filename.empty()) {
+      return;
+   }
+   size_t index = filename.rfind(".");
+   if (index == -1) {
+      filename.append(".ext");
+   }
+   auto ext = filename.substr(index, filename.size());
+   if (ext != ".mtx") {
+      std::cout << "Unsuported file extension" << std::endl;
+      return;
+   }
+   size_t size = t.size();
+
+   std::ofstream file(filename, std::ios::out);
+   file << "%%MatrixMarket matrix array real general\n";
+   file << "%\n";
+   file << size << " 1\n";
+
+   for (size_t i = 0; i < size; i++) {
+      file << t[i] << "\n";
+   }
+}
+
+// Save matrix to a file
+template <class T>
+   requires(::ten::is_matrix<T>::value &&
+            std::is_floating_point_v<typename T::value_type>)
+void save_mtx(const T &t, std::string filename) {
+   std::cout << "Tenseur: Saving Matrix to file " << filename << std::endl;
+   if (filename.empty()) {
+      return;
+   }
+   size_t index = filename.rfind(".");
+   if (index == -1) {
+      filename.append(".ext");
+   }
+   auto ext = filename.substr(index, filename.size());
+   if (ext != ".mtx") {
+      std::cout << "Unsuported file extension\n";
+      return;
+   }
+   size_t m = t.dim(0);
+   size_t n = t.dim(1);
+
+   std::ofstream file(filename, std::ios::out);
+   file << "%%MatrixMarket matrix array real general\n";
+   file << "%\n";
+   file << m << " " << n << "\n";
+
+   for (size_t k = 0; k < m * n; k++) {
+      file << t[k] << "\n";
+   }
+}
+
+} // namespace ten::io
+
+#endif

--- a/ten/ios/serialization.hxx
+++ b/ten/ios/serialization.hxx
@@ -1,0 +1,48 @@
+#ifndef TENSEUR_IOS_SERIALIZATION
+#define TENSEUR_IOS_SERIALIZATION
+
+#include <ten/tensor>
+
+namespace ten::io {
+
+// FIXME Add support for serialization of const tensors
+template <class Tensor>
+   requires(::ten::is_tensor<Tensor>::value)
+bool save(Tensor &t, std::string filename) {
+   size_t index = filename.rfind(".");
+   if (index == -1) {
+      filename.append(".ten");
+   }
+   auto ext = filename.substr(index + 1, filename.size());
+   if (ext != "ten") {
+      std::cerr << "Unsupported file extension, please use .ten extension\n";
+      return false;
+   }
+   std::ofstream ofs(filename, std::ios_base::binary);
+   ten::serialize(ofs, t);
+   ofs.close();
+   return ofs.good();
+}
+
+template <class Tensor>
+   requires(::ten::is_tensor<Tensor>::value)
+std::optional<Tensor> load(const std::string &filename) {
+   size_t index = filename.rfind(".");
+   if (index == -1) {
+      std::cerr << "Unsupported file type\n";
+      return std::nullopt;
+   }
+   auto ext = filename.substr(index + 1, filename.size());
+   if (ext != "ten") {
+      std::cerr << "Unsupported file type\n";
+      return std::nullopt;
+   }
+   std::ifstream ifs(filename, std::ios_base::binary);
+   Tensor t = ten::deserialize<Tensor>(ifs);
+   ifs.close();
+   return t;
+}
+
+} // namespace ten::io
+
+#endif

--- a/ten/kernels/binary_ops.hxx
+++ b/ten/kernels/binary_ops.hxx
@@ -9,13 +9,12 @@
 
 namespace ten::kernels {
 
-template <::ten::binary_operation kind, class A, class B, class C>
-static void binary_ops(const A &a, const B &b, C &c) {
+template<::ten::binary_operation kind, typename T, class A, class B, class C>
+static void binary_ops_32(const A &a, const B &b, C &c) {
    size_t n = a.size();
-   constexpr size_t vlen = ::ten::simd_vecLen;
+   constexpr size_t vlen = ::ten::simd_vecLen_float;
    using ::ten::binary_operation;
-   using T = typename A::value_type;
-   using vector_type = std::experimental::fixed_size_simd<float, vlen>;
+   using vector_type = std::experimental::fixed_size_simd<T, vlen>;
    using alignment = std::experimental::element_aligned_tag;
 
    // max vlen size = 32
@@ -48,7 +47,7 @@ static void binary_ops(const A &a, const B &b, C &c) {
 
    // 16
    constexpr size_t vlen16 = 16;
-   using vector_type16 = std::experimental::fixed_size_simd<float, vlen16>;
+   using vector_type16 = std::experimental::fixed_size_simd<T, vlen16>;
    size_t j = vlen * (n / vlen);
    size_t rest = n - j;
    if (rest >= vlen16) {
@@ -82,7 +81,7 @@ static void binary_ops(const A &a, const B &b, C &c) {
    // 8
    rest = n - j;
    constexpr size_t vlen8 = 8;
-   using vector_type8 = std::experimental::fixed_size_simd<float, vlen8>;
+   using vector_type8 = std::experimental::fixed_size_simd<T, vlen8>;
    if (rest >= vlen8) {
       size_t offset = j;
       vector_type8 a_vec;
@@ -114,7 +113,7 @@ static void binary_ops(const A &a, const B &b, C &c) {
    // 4
    rest = n - j;
    constexpr size_t vlen4 = 4;
-   using vector_type4 = std::experimental::fixed_size_simd<float, vlen4>;
+   using vector_type4 = std::experimental::fixed_size_simd<T, vlen4>;
    if (rest >= vlen4) {
       size_t offset = j;
       vector_type4 a_vec;
@@ -161,6 +160,170 @@ static void binary_ops(const A &a, const B &b, C &c) {
       }
    }
 }
+
+template <::ten::binary_operation kind, typename T, class A, class B, class C>
+static void binary_ops_16(const A &a, const B &b, C &c) {
+   size_t n = a.size();
+   constexpr size_t vlen = ::ten::simd_vecLen_double;
+   using ::ten::binary_operation;
+   using vector_type = std::experimental::fixed_size_simd<T, vlen>;
+   using alignment = std::experimental::element_aligned_tag;
+
+   // max vlen size = 16
+   for (size_t i = 0; i < n / vlen; i++) {
+      // Load a and b
+      size_t offset = i * vlen;
+      vector_type a_vec;
+      a_vec.copy_from(a.data() + offset, alignment{});
+      vector_type b_vec;
+      b_vec.copy_from(b.data() + offset, alignment{});
+      // c_vec = a_vec ops b_vec
+      vector_type c_vec;
+      switch (kind) {
+      case binary_operation::add:
+         c_vec = a_vec + b_vec;
+         break;
+      case binary_operation::sub:
+         c_vec = a_vec - b_vec;
+         break;
+      case binary_operation::div:
+         c_vec = a_vec / b_vec;
+         break;
+      case binary_operation::mul:
+         c_vec = a_vec * b_vec;
+         break;
+      }
+      // Copy back
+      c_vec.copy_to(c.data() + offset, alignment{});
+   }
+
+   // 8
+   size_t j = vlen * (n/vlen);
+   size_t rest = n - j;
+   constexpr size_t vlen8 = 8;
+   using vector_type8 = std::experimental::fixed_size_simd<T, vlen8>;
+   if (rest >= vlen8) {
+      size_t offset = j;
+      vector_type8 a_vec;
+      a_vec.copy_from(a.data() + offset, alignment{});
+      vector_type8 b_vec;
+      b_vec.copy_from(b.data() + offset, alignment{});
+      // c_vec = a_vec ops b_vec
+      vector_type8 c_vec;
+      switch (kind) {
+      case binary_operation::add:
+         c_vec = a_vec + b_vec;
+         break;
+      case binary_operation::sub:
+         c_vec = a_vec - b_vec;
+         break;
+      case binary_operation::div:
+         c_vec = a_vec / b_vec;
+         break;
+      case binary_operation::mul:
+         c_vec = a_vec * b_vec;
+         break;
+      }
+      // copy back data
+      c_vec.copy_to(c.data() + offset, alignment{});
+      // Iter j
+      j += vlen8;
+   }
+
+   // 4
+   rest = n - j;
+   constexpr size_t vlen4 = 4;
+   using vector_type4 = std::experimental::fixed_size_simd<T, vlen4>;
+   if (rest >= vlen4) {
+      size_t offset = j;
+      vector_type4 a_vec;
+      a_vec.copy_from(a.data() + offset, alignment{});
+      vector_type4 b_vec;
+      b_vec.copy_from(b.data() + offset, alignment{});
+      // c_vec = a_vec ops b_vec
+      vector_type4 c_vec;
+      switch (kind) {
+      case binary_operation::add:
+         c_vec = a_vec + b_vec;
+         break;
+      case binary_operation::sub:
+         c_vec = a_vec - b_vec;
+         break;
+      case binary_operation::div:
+         c_vec = a_vec / b_vec;
+         break;
+      case binary_operation::mul:
+         c_vec = a_vec * b_vec;
+         break;
+      }
+      // copy back data
+      c_vec.copy_to(c.data() + offset, alignment{});
+      // Iter j
+      j += vlen4;
+   }
+
+   // Rest
+   for (size_t i = j; i < n; i++) {
+      switch(kind) {
+      case binary_operation::add:
+         c[i] = a[i] + b[i];
+         break;
+      case binary_operation::sub:
+         c[i] = a[i] - b[i];
+         break;
+      case binary_operation::div:
+         c[i] = a[i] / b[i];
+         break;
+      case binary_operation::mul:
+         c[i] = a[i] * b[i];
+         break;
+      }
+   }
+}
+
+/// Binary operation for float
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_float<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_32<kind, float>(a, b, c);
+}
+
+/// Binary operation for double
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_double<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_16<kind, double>(a, b, c);
+}
+
+/// Binary operation for int32
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_int32<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_32<kind, int32_t>(a, b, c);
+}
+
+/// Binary operation for uint32
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_uint32<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_32<kind, uint32_t>(a, b, c);
+}
+
+/// Binary operation for int64
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_int64<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_16<kind, int64_t>(a, b, c);
+}
+
+/// Binary operation for uint64
+template <::ten::binary_operation kind, class A, class B, class C>
+requires(::ten::is_uint64<typename C::value_type>::value)
+static void binary_ops(const A &a, const B &b, C &c) {
+   binary_ops_16<kind, uint64_t>(a, b, c);
+}
+
+// TODO complex<float> and complex<double>
 
 } // namespace ten::kernels
 

--- a/ten/kernels/mul.hxx
+++ b/ten/kernels/mul.hxx
@@ -4,10 +4,9 @@
 #include <ten/types.hxx>
 
 namespace ten::kernels {
-// matrix * vector
-template <class A, class B, class C>
-void mul(const A &a, const B &b, C &c)
-   requires ::ten::is_matrix_node<A>::value && ::ten::is_vector_node<B>::value
+/// Matrix vector multiplication
+template <Matrix A, Vector B, Vector C>
+void mul(A&& a, B &&b, C &c)
 {
    size_t m = a.dim(0);
    size_t n = a.dim(1);
@@ -17,32 +16,30 @@ void mul(const A &a, const B &b, C &c)
    const size_t lda = (transa == transop::no ? m : n);
    const size_t incb = 1;
    const size_t incc = 1;
-   blas::gemv(transa, m, n, T(1.), a.data(), lda, b.data(), incb, T(0.),
+   ::ten::kernels::blas::gemv(transa, m, n, T(1.), a.data(), lda, b.data(), incb, T(0.),
               c.data(), incc);
 }
 
-// Multiply two dense matrices
-// C <- A * B
-template <class A, class B, class C>
-void mul(const A &a, const B &b, C &c)
-   requires ::ten::is_matrix_node<A>::value && ::ten::is_matrix_node<B>::value
-            && ::ten::is_matrix_node<C>::value
+/// Multiply two dense matrices
+/// C <- A * B
+template <Matrix A, Matrix B, Matrix C>
+void mul(A &&a, B &&b, C &c)
 {
    size_t m = a.dim(0);
    size_t k = a.dim(1);
    size_t n = b.dim(1);
    using blas::transop;
-   using T = typename A::value_type;
+   using T = typename std::remove_cvref_t<A>::value_type;
    const transop transa = (a.is_transposed() ? transop::trans : transop::no);
    const transop transb = (b.is_transposed() ? transop::trans : transop::no);
    const size_t lda = (transa == transop::no ? m : k);
    const size_t ldb = (transa == transop::no ? k : n);
-   blas::gemm(transa, transb, m, n, k, T(1.), a.data(), lda, b.data(), ldb,
+   ::ten::kernels::blas::gemm(transa, transb, m, n, k, T(1.), a.data(), lda, b.data(), ldb,
               T(0.), c.data(), m);
 }
 
-// Multiply and add two dense matrices
-// C <- alpha * A * B + beta * C
+/// Multiply and add two dense matrices
+/// C <- alpha * A * B + beta * C
 template <Matrix A, Matrix B, Matrix C, class T>
 void mul_add(A &&a, B &&b, C &c, const T &alpha, const T &beta) {
    size_t m = a.dim(0);
@@ -53,10 +50,11 @@ void mul_add(A &&a, B &&b, C &c, const T &alpha, const T &beta) {
    const transop transb = (b.is_transposed() ? transop::trans : transop::no);
    const size_t lda = (transa == transop::no ? m : k);
    const size_t ldb = (transa == transop::no ? k : n);
-   blas::gemm(transa, transb, m, n, k, alpha, a.data(), lda, b.data(), ldb,
+   ::ten::kernels::blas::gemm(transa, transb, m, n, k, alpha, a.data(), lda, b.data(), ldb,
               beta, c.data(), m);
 }
 
+/// scale and add a vector
 template <Vector X, Vector Y, class T> void axpy(const T a, X &&x, Y &y) {
    size_t n = x.size();
    ::ten::kernels::blas::axpy(n, a, x.data(), 1, y.data(), 1);

--- a/ten/kernels/mul.hxx
+++ b/ten/kernels/mul.hxx
@@ -11,7 +11,7 @@ void mul(A&& a, B &&b, C &c)
    size_t m = a.dim(0);
    size_t n = a.dim(1);
    using blas::transop;
-   using T = typename A::value_type;
+   using T = typename std::remove_cvref_t<A>::value_type;
    const transop transa = (a.is_transposed() ? transop::trans : transop::no);
    const size_t lda = (transa == transop::no ? m : n);
    const size_t incb = 1;

--- a/ten/tensor.hxx
+++ b/ten/tensor.hxx
@@ -95,18 +95,19 @@ template <Expr E, typename T> auto operator-(E &&expr, T &&scalar) {
 }*/
 
 // Multiply two expressions
-/*template <Expr LeftExpr, Expr RightExpr>
+template <Expr LeftExpr, Expr RightExpr>
 auto operator*(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
    using left_input = ::ten::details::input_type<L>::type;
    using right_input = ::ten::details::input_type<R>::type;
-   using output_type = ::ten::details::common_type_t<left_input, right_input>;
+
+   using output_type = ::ten::details::mul_result_t<left_input, right_input>;
 
    return ::ten::binary_expr<L, R, output_type,
        ::ten::functional::mul<left_input, right_input, output_type>::template func>(
        left, right);
-}*/
+}
 
 /*
 template <typename T, Expr E> auto operator*(T &&scalar, E &&expr) {

--- a/ten/tensor.hxx
+++ b/ten/tensor.hxx
@@ -40,42 +40,49 @@ template <typename Derived> class expr {
    expr(expr &&) = default;
 };
 
-
 // Add two expr
 template <Expr LeftExpr, Expr RightExpr>
 auto operator+(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
 
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::binary_func<::ten::binary_operation::add>::func>(left, right);
+   return ::ten::binary_expr<
+       L, R, output_type,
+       ::ten::functional::binary_func<::ten::binary_operation::add>::func>(
+       left, right);
 }
 
 template <typename T, Expr E>
-requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value || std::is_integral_v<T>)
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator+(T &&scalar, E &&expr) {
    using R = std::remove_cvref_t<E>;
    using L = ::ten::scalar<T>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::scalar_left_binary_func<::ten::binary_operation::add>::func>(
-      ::ten::scalar<T>(scalar), expr);
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_left_binary_func<
+                                 ::ten::binary_operation::add>::func>(
+       ::ten::scalar<T>(scalar), expr);
 }
 
-
 template <Expr E, typename T>
-requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value || std::is_integral_v<T>)
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator+(E &&expr, T &&scalar) {
    using L = std::remove_cvref_t<E>;
    using R = ::ten::scalar<T>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::scalar_right_binary_func<::ten::binary_operation::add>::func>(
-      expr, ::ten::scalar<T>(scalar));
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_right_binary_func<
+                                 ::ten::binary_operation::add>::func>(
+       expr, ::ten::scalar<T>(scalar));
 }
 
 // Substract two expressions
@@ -83,37 +90,44 @@ template <Expr LeftExpr, Expr RightExpr>
 auto operator-(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
 
-   return ::ten::binary_expr<L,R, output_type, ::ten::functional::binary_func<::ten::binary_operation::sub>::func>(
+   return ::ten::binary_expr<
+       L, R, output_type,
+       ::ten::functional::binary_func<::ten::binary_operation::sub>::func>(
        left, right);
 }
 
 template <typename T, Expr E>
-requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value || std::is_integral_v<T>)
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator-(T &&scalar, E &&expr) {
    using R = std::remove_cvref_t<E>;
    using L = ::ten::scalar<T>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::scalar_left_binary_func<::ten::binary_operation::sub>::func>(
-      ::ten::scalar<T>(scalar), expr);
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_left_binary_func<
+                                 ::ten::binary_operation::sub>::func>(
+       ::ten::scalar<T>(scalar), expr);
 }
 
-
 template <Expr E, typename T>
-requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value || std::is_integral_v<T>)
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator-(E &&expr, T &&scalar) {
    using L = std::remove_cvref_t<E>;
    using R = ::ten::scalar<T>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::scalar_right_binary_func<::ten::binary_operation::sub>::func>(
-      expr, ::ten::scalar<T>(scalar));
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_right_binary_func<
+                                 ::ten::binary_operation::sub>::func>(
+       expr, ::ten::scalar<T>(scalar));
 }
 
 // Multiply two expressions
@@ -121,27 +135,44 @@ template <Expr LeftExpr, Expr RightExpr>
 auto operator*(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
 
    using output_type = ::ten::details::mul_result_t<left_input, right_input>;
 
-   return ::ten::binary_expr<L, R, output_type,
-       ::ten::functional::mul<left_input, right_input, output_type>::template func>(
-       left, right);
+   return ::ten::binary_expr<
+       L, R, output_type,
+       ::ten::functional::mul<left_input, right_input,
+                              output_type>::template func>(left, right);
 }
-
 
 template <typename T, Expr E>
-// FIXME requires(std::is_floating_point_v<T> || ::ten::is_complex<T> || std::is_integral_v<T>)
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator*(T &&scalar, E &&expr) {
    using R = std::remove_cvref_t<E>;
-   return ::ten::scalar<T>(scalar) * std::forward<R>(expr);
+   using L = ::ten::scalar<T>;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
+   using output_type = ::ten::details::common_type_t<left_input, right_input>;
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_left_binary_func<
+                                 ::ten::binary_operation::mul>::func>(
+       ::ten::scalar<T>(scalar), expr);
 }
 template <Expr E, typename T>
+   requires(::std::is_floating_point_v<T> || ten::is_complex<T>::value ||
+            std::is_integral_v<T>)
 auto operator*(E &&expr, T &&scalar) {
-   using R = std::remove_cvref_t<E>;
-   return ::ten::scalar<T>(scalar) * std::forward<R>(expr);
+   using L = std::remove_cvref_t<E>;
+   using R = ::ten::scalar<T>;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
+   using output_type = ::ten::details::common_type_t<left_input, right_input>;
+   return ::ten::binary_expr<L, R, output_type,
+                             ::ten::functional::scalar_right_binary_func<
+                                 ::ten::binary_operation::mul>::func>(
+       expr, ::ten::scalar<T>(scalar));
 }
 
 // Divide two expressions
@@ -149,11 +180,14 @@ template <Expr LeftExpr, Expr RightExpr>
 auto operator/(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   using left_input = ::ten::details::input_type<L>::type;
-   using right_input = ::ten::details::input_type<R>::type;
+   using left_input = ::ten::details::output_type<L>::type;
+   using right_input = ::ten::details::output_type<R>::type;
    using output_type = ::ten::details::common_type_t<left_input, right_input>;
 
-   return ::ten::binary_expr<L, R, output_type, ::ten::functional::binary_func<::ten::binary_operation::div>::func>(left, right);
+   return ::ten::binary_expr<
+       L, R, output_type,
+       ::ten::functional::binary_func<::ten::binary_operation::div>::func>(
+       left, right);
 }
 
 /*
@@ -202,9 +236,9 @@ class scalar : public expr<scalar<T>>, public scalar_operations<scalar<T>> {
  public:
    scalar() {}
 
-   explicit scalar(const T &value): _value(value) {}
+   explicit scalar(const T &value) : _value(value) {}
 
-   explicit scalar(T&& value) : _value(std::move(value)) {}
+   explicit scalar(T &&value) : _value(std::move(value)) {}
 
    /// Asignment from an expression
    /*template <class Expr>
@@ -221,6 +255,12 @@ class scalar : public expr<scalar<T>>, public scalar_operations<scalar<T>> {
       _value = value;
       return *this;
    }
+
+   scalar &operator=(const scalar &s) {
+      _value = s._value;
+      return *this;
+   }
+
    // ostream operator
    template <class Type>
    friend std::ostream &operator<<(std::ostream &, const scalar<Type> &);
@@ -476,8 +516,7 @@ class tensor_node
 
    /// Construct a tenso_node from storage and shape
    /// FIXME Check size
-   explicit tensor_node(std::unique_ptr<__storage> &&st,
-                        const __shape &dims,
+   explicit tensor_node(std::unique_ptr<__storage> &&st, const __shape &dims,
                         ::ten::storage_format format) noexcept
       requires(__shape::is_dynamic())
        : _format(format), _storage(std::move(st)), _shape(dims),
@@ -855,9 +894,7 @@ class ranked_tensor final
    [[nodiscard]] __t *data() { return _node.get()->data(); }
 
    /// Returns the storage
-   [[nodiscard]] __storage &storage() const {
-      return _node.get()->storage();
-   }
+   [[nodiscard]] __storage &storage() const { return _node.get()->storage(); }
 
    /// Overloading the [] operator
    [[nodiscard]] inline const typename base_type::value_type &
@@ -1867,9 +1904,10 @@ template <class T, class __shape, storage_order __order = default_order,
           class __storage = ::ten::default_storage<T, __shape>,
           class __allocator =
               typename ::ten::details::allocator_type<__storage>::type>
-   requires(::ten::is_dynamic_tensor<ranked_tensor<
-                T, __shape, __order, __storage, __allocator>>::value &&
-            ::ten::is_dense_storage<__storage>::value)
+   requires(
+       ::ten::is_dynamic_tensor<
+           ranked_tensor<T, __shape, __order, __storage, __allocator>>::value &&
+       ::ten::is_dense_storage<__storage>::value)
 [[nodiscard]] auto fill(__shape &&dims, T value) {
    using tensor_type =
        ranked_tensor<T, __shape, __order, __storage, __allocator>;
@@ -1880,9 +1918,10 @@ template <class T, class __shape, storage_order __order = default_order,
           class __storage = ::ten::default_storage<T, __shape>,
           class __allocator =
               typename ::ten::details::allocator_type<__storage>::type>
-   requires(::ten::is_dynamic_tensor<ranked_tensor<
-                T, __shape, __order, __storage, __allocator>>::value &&
-            ::ten::is_dense_storage<__storage>::value)
+   requires(
+       ::ten::is_dynamic_tensor<
+           ranked_tensor<T, __shape, __order, __storage, __allocator>>::value &&
+       ::ten::is_dense_storage<__storage>::value)
 [[nodiscard]] auto fill(std::initializer_list<size_type> &&dims, T value) {
    using tensor_type =
        ranked_tensor<T, __shape, __order, __storage, __allocator>;
@@ -1894,8 +1933,7 @@ template <class T, class __shape, storage_order __order = default_order,
 template <class T, size_type rank, storage_order __order = default_order>
 [[nodiscard]] auto fill(const dynamic_shape<rank> &shape, T value) {
    using shape_type = ::ten::dynamic_shape<rank>;
-   return fill<T, shape_type, __order>(std::forward<shape_type>(shape),
-                                         value);
+   return fill<T, shape_type, __order>(std::forward<shape_type>(shape), value);
 }
 
 template <class T, size_type rank, storage_order __order = default_order>
@@ -2338,7 +2376,7 @@ template <SDiagonal T> auto dense(T x) -> decltype(auto) {
 // Gemm
 // C <- alpha * X * Y + beta * C
 template <Expr X, Expr Y, Tensor C, class T>
-requires(std::is_same_v<T, typename C::value_type>)
+   requires(std::is_same_v<T, typename C::value_type>)
 void gemm(const T alpha, X &&x, Y &&y, const T beta, C &c) {
    using x_expr_type = std::remove_cvref_t<X>;
    using y_expr_type = std::remove_cvref_t<Y>;
@@ -2400,55 +2438,53 @@ void axpy(const T a, X &&x, Y &y) {
 /// Returns the maximum of an expression
 template <Expr ExprType> auto min(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
-   //using output_type = typename ::ten::details::output_type<expr_type>::type;
+   // using output_type = typename ::ten::details::output_type<expr_type>::type;
    using value_type = typename expr_type::value_type;
    using output_type = ten::scalar<value_type>;
    return unary_expr<expr_type, output_type, functional::min>(expr);
 }
 
-/*
 /// \fn max
 /// Return the maximum of an tensor or an expression
 template <Expr ExprType> auto max(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
-   using output_type = typename details::output_type<expr_type>::type;
-   return unary_expr<typename expr_type::node_type, functional::max>(
-       expr.node());
+   using value_type = typename expr_type::value_type;
+   using output_type = ten::scalar<value_type>;
+   return unary_expr<expr_type, output_type, functional::max>(expr);
 }
 
 /// \fn sum
-/// Return the maximum of an tensor or an expression
+/// Return the sum of a tensor or an expression
 template <Expr ExprType> auto sum(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
-   using output_type = typename details::output_type<expr_type>::type;
-   return unary_expr<typename expr_type::node_type, functional::sum>(
-       expr.node());
+   using value_type = typename expr_type::value_type;
+   using output_type = ten::scalar<value_type>;
+   return unary_expr<expr_type, output_type, functional::sum>(expr);
 }
 
 /// \fn cum_sum
-/// Return the maximum of an tensor or an expression
+/// Return the cumulative sum of a tensor or an expression
 template <Expr ExprType> auto cum_sum(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename details::output_type<expr_type>::type;
-   return unary_expr<typename expr_type::node_type, functional::cum_sum>(
-       expr.node());
+   return unary_expr<expr_type, output_type, functional::cum_sum>(expr);
 }
-/// \fn sum
+
+/// \fn prod
 /// Return the maximum of an tensor or an expression
 template <Expr ExprType> auto prod(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
-   using output_type = typename details::output_type<expr_type>::type;
-   return unary_expr<typename expr_type::node_type, functional::prod>(
-       expr.node());
-}*/
-
+   using value_type = typename expr_type::value_type;
+   using output_type = ten::scalar<value_type>;
+   return unary_expr<expr_type, output_type, functional::prod>(expr);
+}
 
 /// \fn abs
 /// Returns the absolute value of a scalar, a tensor or an expression
 template <Expr ExprType> auto abs(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::abs >(expr);
+   return unary_expr<expr_type, output_type, functional::abs>(expr);
 }
 
 /// \fn sqrt
@@ -2488,7 +2524,7 @@ template <Expr ExprType> auto sinh(ExprType &&expr) {
 template <Expr ExprType> auto asin(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type,output_type, functional::asin>(expr);
+   return unary_expr<expr_type, output_type, functional::asin>(expr);
 }
 
 /// \fn cos
@@ -2496,8 +2532,7 @@ template <Expr ExprType> auto asin(ExprType &&expr) {
 template <Expr ExprType> auto cos(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::cos>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::cos>(expr);
 }
 
 /// \fn acos
@@ -2511,8 +2546,7 @@ template <Expr ExprType> auto acos(ExprType &&expr) {
 template <Expr ExprType> auto cosh(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::cosh>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::cosh>(expr);
 }
 
 /// \fn tan
@@ -2520,24 +2554,21 @@ template <Expr ExprType> auto cosh(ExprType &&expr) {
 template <Expr ExprType> auto tan(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::tan>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::tan>(expr);
 }
 
 /// \fn atan
 template <Expr ExprType> auto atan(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::atan>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::atan>(expr);
 }
 
 /// \fn tanh
 template <Expr ExprType> auto tanh(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::tanh>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::tanh>(expr);
 }
 
 /// \fn exp
@@ -2545,8 +2576,7 @@ template <Expr ExprType> auto tanh(ExprType &&expr) {
 template <Expr ExprType> auto exp(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::exp>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::exp>(expr);
 }
 
 /// \fn log
@@ -2554,24 +2584,21 @@ template <Expr ExprType> auto exp(ExprType &&expr) {
 template <Expr ExprType> auto log(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::log>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::log>(expr);
 }
 
 /// \fn log10
 template <Expr ExprType> auto log10(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::log10>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::log10>(expr);
 }
 
 /// \fn floor
 template <Expr ExprType> auto floor(ExprType &&expr) {
    using expr_type = std::remove_cvref_t<ExprType>;
    using output_type = typename ::ten::details::output_type<expr_type>::type;
-   return unary_expr<expr_type, output_type, functional::floor>(
-       expr);
+   return unary_expr<expr_type, output_type, functional::floor>(expr);
 }
 
 /// \fn ceil

--- a/ten/tensor.hxx
+++ b/ten/tensor.hxx
@@ -64,18 +64,20 @@ template <Expr E, typename T>
 auto operator+(E &&expr, T &&scalar) {
    using R = std::remove_cvref_t<E>;
    return std::forward<R>(expr) + ::ten::scalar<T>(scalar);
-}
+}*/
 
 // Substract two expressions
 template <Expr LeftExpr, Expr RightExpr>
 auto operator-(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   return ::ten::binary_expr<
-       typename L::node_type, typename R::node_type,
-       ::ten::functional::binary_func<::ten::binary_operation::sub>::func>(
-       left.node(), right.node());
-}*/
+   using left_input = ::ten::details::input_type<L>::type;
+   using right_input = ::ten::details::input_type<R>::type;
+   using output_type = ::ten::details::common_type_t<left_input, right_input>;
+
+   return ::ten::binary_expr<L,R, output_type, ::ten::functional::binary_func<::ten::binary_operation::sub>::func>(
+       left, right);
+}
 
 
 /*FIXME
@@ -90,20 +92,23 @@ auto operator-(T &&scalar, E &&expr) {
 template <Expr E, typename T> auto operator-(E &&expr, T &&scalar) {
    using R = std::remove_cvref_t<E>;
    return std::forward<R>(expr) - ::ten::scalar<T>(scalar);
-}
+}*/
 
 // Multiply two expressions
-template <Expr LeftExpr, Expr RightExpr>
+/*template <Expr LeftExpr, Expr RightExpr>
 auto operator*(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   return ::ten::binary_expr<
-       typename L::node_type, typename R::node_type,
-       ::ten::functional::mul<typename L::node_type,
-                              typename R::node_type>::template func>(
-       left.node(), right.node());
-}
+   using left_input = ::ten::details::input_type<L>::type;
+   using right_input = ::ten::details::input_type<R>::type;
+   using output_type = ::ten::details::common_type_t<left_input, right_input>;
 
+   return ::ten::binary_expr<L, R, output_type,
+       ::ten::functional::mul<left_input, right_input, output_type>::template func>(
+       left, right);
+}*/
+
+/*
 template <typename T, Expr E> auto operator*(T &&scalar, E &&expr) {
    using R = std::remove_cvref_t<E>;
    return ::ten::scalar<T>(scalar) * std::forward<std::remove_cvref_t<E>>(expr);
@@ -116,17 +121,18 @@ auto operator*(E &&expr, T &&scalar) {
    return std::forward<R>(expr) * ::ten::scalar<T>(scalar);
 }*/
 
-/*
+
 // Divide two expressions
 template <Expr LeftExpr, Expr RightExpr>
 auto operator/(LeftExpr &&left, RightExpr &&right) {
    using L = std::remove_cvref_t<LeftExpr>;
    using R = std::remove_cvref_t<RightExpr>;
-   return ::ten:binary_expr<
-       typename L::node_type, typename R::node_type,
-       ::ten::functional::binary_func<::ten::binary_operation::div>::func>(
-       left.node(), right.node());
-}*/
+   using left_input = ::ten::details::input_type<L>::type;
+   using right_input = ::ten::details::input_type<R>::type;
+   using output_type = ::ten::details::common_type_t<left_input, right_input>;
+
+   return ::ten::binary_expr<L, R, output_type, ::ten::functional::binary_func<::ten::binary_operation::div>::func>(left, right);
+}
 
 /*FIXME 
 template <typename T, typename E>

--- a/ten/tensor.hxx
+++ b/ten/tensor.hxx
@@ -109,17 +109,19 @@ auto operator*(LeftExpr &&left, RightExpr &&right) {
        left, right);
 }
 
-/*
-template <typename T, Expr E> auto operator*(T &&scalar, E &&expr) {
+
+template <typename T, Expr E>
+// FIXME requires(std::is_floating_point_v<T> || ::ten::is_complex<T> || std::is_integral_v<T>)
+auto operator*(T &&scalar, E &&expr) {
    using R = std::remove_cvref_t<E>;
-   return ::ten::scalar<T>(scalar) * std::forward<std::remove_cvref_t<E>>(expr);
-}*/
+   return ::ten::scalar<T>(scalar) * std::forward<R>(expr);
+}
 
 /*FIXME 
 template <Expr E, typename T>
 auto operator*(E &&expr, T &&scalar) {
    using R = std::remove_cvref_t<E>;
-   return std::forward<R>(expr) * ::ten::scalar<T>(scalar);
+   return ::ten::scalar<T>(scalar) * std::forward<R>(expr);
 }*/
 
 

--- a/ten/types.hxx
+++ b/ten/types.hxx
@@ -144,6 +144,10 @@ template <class T> class scalar;
 template <class> struct is_scalar : std::false_type {};
 template <class T> struct is_scalar<scalar<T>> : std::true_type {};
 
+// Scalar concept
+template <class T>
+concept Scalar = is_scalar<std::remove_cvref_t<T>>::value;
+
 // Forward declaration of tensor operations
 template <class T, class Shape, storage_order Order, class Storage,
           class Allocator>

--- a/ten/types.hxx
+++ b/ten/types.hxx
@@ -410,34 +410,37 @@ struct is_tensor_node<tensor_node<T, shape, order, storage, allocator>>
 // Unary Node
 template <class input, class output, template <typename...> class Func,
           typename... Args>
-class unary_node;
+class unary_expr;
 
-template <class> struct is_unary_node : std::false_type {};
+template <class> struct is_unary_expr : std::false_type {};
 template <class input, class output, template <typename...> class Func,
           typename... Args>
-struct is_unary_node<unary_node<input, output, Func, Args...>>
+struct is_unary_expr<unary_expr<input, output, Func, Args...>>
     : std::true_type {};
 
 // Unary Expr
+/*
 template <class E, template <typename...> class Func, typename... Args>
 class unary_expr;
 
 template <class> struct is_unary_expr : std::false_type {};
 template <class E, template <typename...> class Func, typename... Args>
 struct is_unary_expr<unary_expr<E, Func, Args...>> : std::true_type {};
+*/
 
 // Binary Node
 template <class left, class right, class output,
           template <typename...> class Func, typename... Args>
-class binary_node;
+class binary_expr;
 
-template <class> struct is_binary_node : std::false_type {};
+template <class> struct is_binary_expr : std::false_type {};
 template <class left, class right, class O, template <typename...> class Func,
           typename... Args>
-struct is_binary_node<binary_node<left, right, O, Func, Args...>>
+struct is_binary_expr<binary_expr<left, right, O, Func, Args...>>
     : std::true_type {};
 
 // Binary Expr
+/*
 template <class left, class right, template <typename...> class Func,
           typename... Args>
 class binary_expr;
@@ -447,11 +450,20 @@ template <class left, class right, template <typename...> class Func,
           typename... Args>
 struct is_binary_expr<binary_expr<left, right, Func, Args...>>
     : std::true_type {};
+*/
 
 /////////////////////////////////////////////////////////////////////////////////
 // Concepts
 
 /// Unary node
+template <class T>
+concept UnaryExpr = is_unary_expr<T>::value;
+
+/// Binary node
+template <class T>
+concept BinaryExpr = is_binary_expr<T>::value;
+
+/*/// Unary node
 template <class T>
 concept UnaryNode = is_unary_node<T>::value;
 
@@ -461,7 +473,7 @@ concept BinaryNode = is_binary_node<T>::value;
 
 /// Unary or binary node
 template <class T>
-concept Node = UnaryNode<T> || BinaryNode<T>;
+concept Node = UnaryNode<T> || BinaryNode<T>;*/
 
 /// Diagonal matrix
 template <typename T>

--- a/ten/types.hxx
+++ b/ten/types.hxx
@@ -76,6 +76,34 @@ using size_type = TENSEUR_SIZE_TYPE;
 template <class> struct is_complex : std::false_type {};
 template <class T> struct is_complex<std::complex<T>> : std::true_type {};
 
+// Traits for float
+template<class> struct is_float : std::false_type {};
+template<> struct is_float<float> : std::true_type {};
+
+// Traits for double
+template<class> struct is_double : std::false_type {};
+template<> struct is_double<double> : std::true_type {};
+
+// Traits for int32
+template<class> struct is_int32 : std::false_type {};
+template<> struct is_int32<int32_t> : std::true_type {};
+
+// Traits for uint32
+template<class> struct is_uint32 : std::false_type {};
+template<> struct is_uint32<uint32_t> : std::true_type {};
+
+// Traits for int64
+template<class> struct is_int64 : std::false_type {};
+template<> struct is_int64<int64_t> : std::true_type {};
+
+// Traits for uint64
+template<class> struct is_uint64 : std::false_type {};
+template<> struct is_uint64<uint64_t> : std::true_type {};
+
+// Traits for bool
+template<class> struct is_bool : std::false_type {};
+template<> struct is_bool<bool> : std::true_type {};
+
 // Forward declaration of shape
 template <size_type Dim, size_type... Rest> class shape;
 

--- a/ten/types.hxx
+++ b/ten/types.hxx
@@ -77,32 +77,32 @@ template <class> struct is_complex : std::false_type {};
 template <class T> struct is_complex<std::complex<T>> : std::true_type {};
 
 // Traits for float
-template<class> struct is_float : std::false_type {};
-template<> struct is_float<float> : std::true_type {};
+template <class> struct is_float : std::false_type {};
+template <> struct is_float<float> : std::true_type {};
 
 // Traits for double
-template<class> struct is_double : std::false_type {};
-template<> struct is_double<double> : std::true_type {};
+template <class> struct is_double : std::false_type {};
+template <> struct is_double<double> : std::true_type {};
 
 // Traits for int32
-template<class> struct is_int32 : std::false_type {};
-template<> struct is_int32<int32_t> : std::true_type {};
+template <class> struct is_int32 : std::false_type {};
+template <> struct is_int32<int32_t> : std::true_type {};
 
 // Traits for uint32
-template<class> struct is_uint32 : std::false_type {};
-template<> struct is_uint32<uint32_t> : std::true_type {};
+template <class> struct is_uint32 : std::false_type {};
+template <> struct is_uint32<uint32_t> : std::true_type {};
 
 // Traits for int64
-template<class> struct is_int64 : std::false_type {};
-template<> struct is_int64<int64_t> : std::true_type {};
+template <class> struct is_int64 : std::false_type {};
+template <> struct is_int64<int64_t> : std::true_type {};
 
 // Traits for uint64
-template<class> struct is_uint64 : std::false_type {};
-template<> struct is_uint64<uint64_t> : std::true_type {};
+template <class> struct is_uint64 : std::false_type {};
+template <> struct is_uint64<uint64_t> : std::true_type {};
 
 // Traits for bool
-template<class> struct is_bool : std::false_type {};
-template<> struct is_bool<bool> : std::true_type {};
+template <class> struct is_bool : std::false_type {};
+template <> struct is_bool<bool> : std::true_type {};
 
 // Forward declaration of shape
 template <size_type Dim, size_type... Rest> class shape;
@@ -208,9 +208,33 @@ struct is_vector<ranked_tensor<Scalar, Shape, order, Storage, Allocator>> {
    static constexpr bool value = Shape::rank() == 1;
 };
 
+// Dynamic vector
+template <typename> struct is_dynamic_vector : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_dynamic_vector<ranked_tensor<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_dynamic() && shape::rank() == 1;
+};
+
+// Static vector
+template <typename> struct is_svector : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_svector<ranked_tensor<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_static() && shape::rank() == 1;
+};
+
 /// Concept Vector dense
 template <class T>
 concept Vector = is_vector<std::remove_cvref_t<T>>::value;
+
+/// Concept Dynamic vector
+template <class T>
+concept DynamicVector = is_dynamic_vector<std::remove_cvref_t<T>>::value;
+
+/// Concept Static vector
+template <class T>
+concept StaticVector = is_svector<std::remove_cvref_t<T>>::value;
 
 /// Column type
 template <class T, class shape, storage_order order, class storage,
@@ -243,6 +267,38 @@ concept Column = is_column<std::remove_cvref_t<T>>::value;
 /// Concept Row
 template <class T>
 concept Row = is_row<std::remove_cvref_t<T>>::value;
+
+// Dynamic column
+template <typename> struct is_dynamic_column : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_dynamic_column<ranked_column<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_dynamic();
+};
+
+// Static column
+template <typename> struct is_scolumn : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_scolumn<ranked_column<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_static();
+};
+
+// Dynamic row
+template <typename> struct is_dynamic_row : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_dynamic_row<ranked_row<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_dynamic();
+};
+
+// Static row
+template <typename> struct is_srow : std::false_type {};
+template <class T, class shape, storage_order order, class storage,
+          class allocator>
+struct is_srow<ranked_row<T, shape, order, storage, allocator>> {
+   static constexpr bool value = shape::is_static();
+};
 
 /// Matrix (dense)
 template <typename> struct is_matrix : std::false_type {};
@@ -279,7 +335,7 @@ struct is_dynamic_tensor<ranked_tensor<T, shape, order, allocator, storage>> {
 };
 
 template <class T>
-concept DynamicTensor = is_dynamic_tensor<T>::value;
+concept DynamicTensor = is_dynamic_tensor<std::remove_cvref_t<T>>::value;
 
 // Static tensor
 template <typename> struct is_stensor : std::false_type {};
@@ -290,22 +346,14 @@ struct is_stensor<ranked_tensor<T, shape, order, storage, allocator>> {
 };
 
 template <class T>
-concept StaticTensor = is_stensor<T>::value;
+concept StaticTensor = is_stensor<std::remove_cvref_t<T>>::value;
 
-// Dynamic vector
+// FIXME Remove this Dynamic vector
 template <typename> struct is_dvector : std::false_type {};
 template <class T, class shape, storage_order order, class storage,
           class allocator>
 struct is_dvector<ranked_tensor<T, shape, order, storage, allocator>> {
    static constexpr bool value = shape::is_dynamic() && shape::rank() == 1;
-};
-
-// Static vector
-template <typename> struct is_svector : std::false_type {};
-template <class T, class shape, storage_order order, class storage,
-          class allocator>
-struct is_svector<ranked_tensor<T, shape, order, storage, allocator>> {
-   static constexpr bool value = shape::is_static() && shape::rank() == 1;
 };
 
 /// \typedef default_allocator

--- a/ten/utils.hxx
+++ b/ten/utils.hxx
@@ -10,13 +10,19 @@
 namespace ten {
 template <class> std::string to_string();
 
+template <> std::string to_string<bool>() { return "bool"; }
+
 template <> std::string to_string<float>() { return "float"; }
 
-template <> std::string to_string<int>() { return "int32"; }
-
-template <> std::string to_string<long>() { return "int64"; }
-
 template <> std::string to_string<double>() { return "double"; }
+
+template <> std::string to_string<int32_t>() { return "int32"; }
+
+template <> std::string to_string<uint32_t>() { return "uint32"; }
+
+template <> std::string to_string<int64_t>() { return "int64"; }
+
+template <> std::string to_string<uint64_t>() { return "uint64"; }
 
 template <> std::string to_string<std::complex<float>>() {
    return "complex<float>";


### PR DESCRIPTION
With the limitations of the expressions API, I decided to make a new one based on the old API.
This shouldn't be a breaking change and all functions defined on expression must behave the same.

Feature list:
- [x]  Make `ten::unary_expr` work
- [x] Make `ten::unary_expr` work with chaining expressions
- [x] Make `ten::unary_expr` work with fonction that returns a `ten::scalar`
- [x] Make `ten::binary_expr` work with basic add, div, and sub
- [x] Make `ten::binary_expr` work for matrix multiplication
- [x] Make `ten::binary_expr` work for matrix vector multiplication
- [x] Make `ten::binary_expr` work with chaining expressions
- [x] Rework the functions defined on expressions (`pow`, `cos`, `sin`, `tan`, ...)
- [x] Rework assignment to tensor from expressions
- [x] Make expressions work with `ranked_column` and `ranked_row`
- [x] Assign expressions to `ranked_column` and `ranked_row`
- [x] Make storage std::unique_ptr instead of shared_ptr